### PR TITLE
[Add] Record : 러닝 기록 API 구현 (저장, 전체 조회, 코스별 조회)

### DIFF
--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/code/DateConstants.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/code/DateConstants.java
@@ -1,0 +1,10 @@
+package com.runtracker_prototype.code;
+
+public class DateConstants {
+    private DateConstants() {
+    }
+    
+    public static final String DATE_PATTERN = "yyyy-MM-dd";
+    public static final String DATETIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    public static final String TIME_ZONE = "Asia/Seoul";
+}

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/controller/RecordController.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/controller/RecordController.java
@@ -1,12 +1,12 @@
 package com.runtracker_prototype.controller;
 
+import com.runtracker_prototype.code.CommonResponseCode;
 import com.runtracker_prototype.dto.RecordDTO;
+import com.runtracker_prototype.response.ApiResponse;
 import com.runtracker_prototype.service.RecordService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,29 +25,21 @@ public class RecordController {
     
     @Operation(summary = "전체 기록 불러오기", description = "전체 기록을 시간순으로 반환")
     @GetMapping
-    public ResponseEntity<List<RecordDTO>> getRecords() {
+    public ApiResponse<List<RecordDTO>> getRecords() {
         try {
-            return ResponseEntity
-                    .status(HttpStatus.OK)
-                    .body(new ArrayList<>());
+            return ApiResponse.ok(new ArrayList<>());
         } catch (Exception e) {
-            return ResponseEntity
-                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ArrayList<>());
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
         }
     }
     
     @Operation(summary = "코스별 기록 불러오기", description = "코스별 기록을 시간순으로 반환")
     @GetMapping("/{courseId}")
-    public ResponseEntity<List<RecordDTO>> getRecordsByCourseId(@PathVariable Long courseId) {
+    public ApiResponse<List<RecordDTO>> getRecordsByCourseId(@PathVariable Long courseId) {
         try {
-            return ResponseEntity
-                    .status(HttpStatus.OK)
-                    .body(new ArrayList<>());
+            return ApiResponse.ok(new ArrayList<>());
         } catch (Exception e) {
-            return ResponseEntity
-                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ArrayList<>());
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/controller/RecordController.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/controller/RecordController.java
@@ -5,6 +5,9 @@ import com.runtracker_prototype.dto.RecordDTO;
 import com.runtracker_prototype.response.ApiResponse;
 import com.runtracker_prototype.service.RecordService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +15,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 
 @RestController
 @RequestMapping("/proto/records")
@@ -24,10 +27,16 @@ public class RecordController {
     private final RecordService recordService;
     
     @Operation(summary = "전체 기록 불러오기", description = "전체 기록을 시간순으로 반환")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = RecordDTO.class)))
+    })
     @GetMapping
     public ApiResponse<List<RecordDTO>> getRecords() {
         try {
-            return ApiResponse.ok(new ArrayList<>());
+            List<RecordDTO> records = recordService.getAllRecords();
+            return ApiResponse.ok(records);
         } catch (Exception e) {
             return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
         }

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/controller/RecordController.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/controller/RecordController.java
@@ -2,21 +2,15 @@ package com.runtracker_prototype.controller;
 
 import com.runtracker_prototype.code.CommonResponseCode;
 import com.runtracker_prototype.dto.RecordDTO;
+import com.runtracker_prototype.exception.CustomException;
 import com.runtracker_prototype.response.ApiResponse;
 import com.runtracker_prototype.service.RecordService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.ArrayList;
 
 @RestController
 @RequestMapping("/proto/records")
@@ -26,17 +20,27 @@ public class RecordController {
 
     private final RecordService recordService;
     
+    @Operation(summary = "러닝 기록 저장", description = "러닝이 끝난 후 기록을 저장 (시간은 자동으로 현재 시간으로 저장됨)")
+    @PostMapping
+    public ApiResponse<RecordDTO> saveRecord(@RequestBody RecordDTO recordDTO) {
+        try {
+            RecordDTO savedRecord = recordService.saveRecord(recordDTO);
+            return ApiResponse.ok(savedRecord);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getErrorCode());
+        } catch (Exception e) {
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     @Operation(summary = "전체 기록 불러오기", description = "전체 기록을 시간순으로 반환")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
-            content = @Content(mediaType = "application/json",
-                schema = @Schema(implementation = RecordDTO.class)))
-    })
     @GetMapping
     public ApiResponse<List<RecordDTO>> getRecords() {
         try {
             List<RecordDTO> records = recordService.getAllRecords();
             return ApiResponse.ok(records);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getErrorCode());
         } catch (Exception e) {
             return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
         }
@@ -44,9 +48,12 @@ public class RecordController {
     
     @Operation(summary = "코스별 기록 불러오기", description = "코스별 기록을 시간순으로 반환")
     @GetMapping("/{courseId}")
-    public ApiResponse<List<RecordDTO>> getRecordsByCourseId(@PathVariable Long courseId) {
+    public ApiResponse<List<RecordDTO>> getRecordsByCourseId(@PathVariable("courseId") Long courseId) {
         try {
-            return ApiResponse.ok(new ArrayList<>());
+            List<RecordDTO> records = recordService.getRecordsByCourseId(courseId);
+            return ApiResponse.ok(records);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getErrorCode());
         } catch (Exception e) {
             return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
         }

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/domain/Record.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/domain/Record.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @ToString
 public class Record {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "record_id")
     private Long id;
 

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/dto/RecordDTO.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/dto/RecordDTO.java
@@ -13,7 +13,14 @@ import java.time.LocalDateTime;
 public class RecordDTO {
     private Long id; // 기록 id
     private Long courseId; // 코스 id
-    private LocalDateTime time; // 걸린 시간
+    private LocalDateTime time; // 걸린 시간 (자동 설정)
     private Integer kcal; // 칼로리
     private Integer walkCnt; // 걸음 수
+
+    // 기록 생성 시 사용할 생성자
+    public RecordDTO(Long courseId, Integer kcal, Integer walkCnt) {
+        this.courseId = courseId;
+        this.kcal = kcal;
+        this.walkCnt = walkCnt;
+    }
 }

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/errorCode/CourseErrorCode.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/errorCode/CourseErrorCode.java
@@ -14,8 +14,7 @@ public enum CourseErrorCode implements ResponseCode {
     INVALID_COORDINATE_DATA("CS004", "유효하지 않은 좌표 데이터입니다"),
     NO_COURSES_FOUND("CS005", "주변에 러닝 코스가 없습니다"),
     DIFFICULTY_REQUIRED("CS006", "코스 난이도는 필수 값입니다"),
-    INVALID_DIFFICULTY("CS007", "유효하지 않은 난이도입니다. EASY, MEDIUM, HARD 중 하나여야 합니다"),
-    NO_RECORDS_FOUND("CS008", "기록이 존재하지 않습니다");
+    INVALID_DIFFICULTY("CS007", "유효하지 않은 난이도입니다. EASY, MEDIUM, HARD 중 하나여야 합니다");
 
     private final String statusCode;
     private final String message;

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/errorCode/CourseErrorCode.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/errorCode/CourseErrorCode.java
@@ -14,7 +14,8 @@ public enum CourseErrorCode implements ResponseCode {
     INVALID_COORDINATE_DATA("CS004", "유효하지 않은 좌표 데이터입니다"),
     NO_COURSES_FOUND("CS005", "주변에 러닝 코스가 없습니다"),
     DIFFICULTY_REQUIRED("CS006", "코스 난이도는 필수 값입니다"),
-    INVALID_DIFFICULTY("CS007", "유효하지 않은 난이도입니다. EASY, MEDIUM, HARD 중 하나여야 합니다");
+    INVALID_DIFFICULTY("CS007", "유효하지 않은 난이도입니다. EASY, MEDIUM, HARD 중 하나여야 합니다"),
+    NO_RECORDS_FOUND("CS008", "기록이 존재하지 않습니다");
 
     private final String statusCode;
     private final String message;

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/errorCode/RecordErrorCode.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/errorCode/RecordErrorCode.java
@@ -1,0 +1,21 @@
+package com.runtracker_prototype.errorCode;
+
+import com.runtracker_prototype.code.ResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecordErrorCode implements ResponseCode {
+    
+    NO_RECORDS_FOUND("RC001", "기록이 존재하지 않습니다"),
+    RECORD_COURSE_ID_REQUIRED("RC002", "코스 ID는 필수 값입니다"),
+    RECORD_TIME_REQUIRED("RC003", "러닝 시간은 필수 값입니다"),
+    RECORD_KCAL_REQUIRED("RC004", "소모 칼로리는 필수 값입니다"),
+    RECORD_WALK_COUNT_REQUIRED("RC005", "걸음 수는 필수 값입니다"),
+    INVALID_DATETIME_FORMAT("RC006", "잘못된 날짜/시간 형식입니다"),
+    COURSE_NOT_FOUND_FOR_RECORD("RC007", "기록을 저장하려는 코스가 존재하지 않습니다");
+
+    private final String statusCode;
+    private final String message;
+}

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/exception/NoRecordsFoundException.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/exception/NoRecordsFoundException.java
@@ -1,0 +1,9 @@
+package com.runtracker_prototype.exception;
+
+import com.runtracker_prototype.errorCode.CourseErrorCode;
+
+public class NoRecordsFoundException extends CustomException {
+    public NoRecordsFoundException() {
+        super(CourseErrorCode.NO_RECORDS_FOUND);
+    }
+} 

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/exception/NoRecordsFoundException.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/exception/NoRecordsFoundException.java
@@ -1,9 +1,9 @@
 package com.runtracker_prototype.exception;
 
-import com.runtracker_prototype.errorCode.CourseErrorCode;
+import com.runtracker_prototype.errorCode.RecordErrorCode;
 
 public class NoRecordsFoundException extends CustomException {
     public NoRecordsFoundException() {
-        super(CourseErrorCode.NO_RECORDS_FOUND);
+        super(RecordErrorCode.NO_RECORDS_FOUND);
     }
 } 

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/repository/RecordRepository.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/repository/RecordRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long> {
     List<Record> findAllByOrderByTimeDesc();
+    List<Record> findAllByCourse_IdOrderByTimeDesc(Long courseId);
 }

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/repository/RecordRepository.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/repository/RecordRepository.java
@@ -4,6 +4,9 @@ import com.runtracker_prototype.domain.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long> {
+    List<Record> findAllByOrderByTimeDesc();
 }

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/service/RecordService.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/service/RecordService.java
@@ -1,13 +1,21 @@
 package com.runtracker_prototype.service;
 
+import com.runtracker_prototype.code.DateConstants;
+import com.runtracker_prototype.domain.Course;
 import com.runtracker_prototype.domain.Record;
 import com.runtracker_prototype.dto.RecordDTO;
-import com.runtracker_prototype.exception.NoRecordsFoundException;
+import com.runtracker_prototype.errorCode.CourseErrorCode;
+import com.runtracker_prototype.errorCode.RecordErrorCode;
+import com.runtracker_prototype.exception.CustomException;
+import com.runtracker_prototype.repository.CourseRepository;
 import com.runtracker_prototype.repository.RecordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,12 +25,85 @@ import java.util.stream.Collectors;
 public class RecordService {
     
     private final RecordRepository recordRepository;
+    private final CourseRepository courseRepository;
+
+    @Transactional
+    public RecordDTO saveRecord(RecordDTO recordDTO) {
+        validateRecord(recordDTO);
+        
+        Course course = courseRepository.findById(recordDTO.getCourseId())
+                .orElseThrow(() -> new CustomException(RecordErrorCode.COURSE_NOT_FOUND_FOR_RECORD));
+
+        // 현재 시간을 Asia/Seoul 기준으로 설정
+        LocalDateTime currentTime = LocalDateTime.now(ZoneId.of(DateConstants.TIME_ZONE));
+
+        Record record = Record.builder()
+                .course(course)
+                .time(currentTime)
+                .kcal(recordDTO.getKcal())
+                .walkCnt(recordDTO.getWalkCnt())
+                .build();
+
+        Record savedRecord = recordRepository.save(record);
+        
+        return new RecordDTO(
+                savedRecord.getId(),
+                savedRecord.getCourse().getId(),
+                savedRecord.getTime(),
+                savedRecord.getKcal(),
+                savedRecord.getWalkCnt()
+        );
+    }
+
+    private void validateRecord(RecordDTO recordDTO) {
+        if (recordDTO.getCourseId() == null) {
+            throw new CustomException(RecordErrorCode.RECORD_COURSE_ID_REQUIRED);
+        }
+        if (recordDTO.getKcal() == null) {
+            throw new CustomException(RecordErrorCode.RECORD_KCAL_REQUIRED);
+        }
+        if (recordDTO.getWalkCnt() == null) {
+            throw new CustomException(RecordErrorCode.RECORD_WALK_COUNT_REQUIRED);
+        }
+    }
+
+    private LocalDateTime parseDateTime(LocalDateTime dateTime) {
+        try {
+            return dateTime.atZone(ZoneId.of("UTC"))
+                    .withZoneSameInstant(ZoneId.of(DateConstants.TIME_ZONE))
+                    .toLocalDateTime();
+        } catch (DateTimeParseException e) {
+            throw new CustomException(RecordErrorCode.INVALID_DATETIME_FORMAT);
+        }
+    }
 
     public List<RecordDTO> getAllRecords() {
         List<Record> records = recordRepository.findAllByOrderByTimeDesc();
         
         if (records.isEmpty()) {
-            throw new NoRecordsFoundException();
+            throw new CustomException(RecordErrorCode.NO_RECORDS_FOUND);
+        }
+
+        return records.stream()
+                .map(record -> new RecordDTO(
+                        record.getId(),
+                        record.getCourse().getId(),
+                        record.getTime(),
+                        record.getKcal(),
+                        record.getWalkCnt()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public List<RecordDTO> getRecordsByCourseId(Long courseId) {
+        // 코스 존재 여부 확인
+        courseRepository.findById(courseId)
+                .orElseThrow(() -> new CustomException(RecordErrorCode.COURSE_NOT_FOUND_FOR_RECORD));
+
+        List<Record> records = recordRepository.findAllByCourse_IdOrderByTimeDesc(courseId);
+        
+        if (records.isEmpty()) {
+            throw new CustomException(RecordErrorCode.NO_RECORDS_FOUND);
         }
 
         return records.stream()

--- a/runtracker-prototype/src/main/java/com/runtracker_prototype/service/RecordService.java
+++ b/runtracker-prototype/src/main/java/com/runtracker_prototype/service/RecordService.java
@@ -1,9 +1,38 @@
 package com.runtracker_prototype.service;
 
+import com.runtracker_prototype.domain.Record;
+import com.runtracker_prototype.dto.RecordDTO;
+import com.runtracker_prototype.exception.NoRecordsFoundException;
+import com.runtracker_prototype.repository.RecordRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RecordService {
+    
+    private final RecordRepository recordRepository;
+
+    public List<RecordDTO> getAllRecords() {
+        List<Record> records = recordRepository.findAllByOrderByTimeDesc();
+        
+        if (records.isEmpty()) {
+            throw new NoRecordsFoundException();
+        }
+
+        return records.stream()
+                .map(record -> new RecordDTO(
+                        record.getId(),
+                        record.getCourse().getId(),
+                        record.getTime(),
+                        record.getKcal(),
+                        record.getWalkCnt()
+                ))
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 🚀 기록(Record) API 구현

### 📌 주요 기능

#### ✅ 1. 러닝 기록 저장
- **Endpoint**: `POST /proto/records`
- **설명**: 러닝 종료 후 kcal 및 걸음 수 데이터를 저장하며, 시간은 서버 기준 현재 시간으로 자동 입력됨
- **요청 데이터** (`RecordDTO`):
  ```json
  {
    "courseId": 1,
    "kcal": 300,
    "walkCnt": 5200
  }
#### ✅ 2. 전체 기록 조회
- Endpoint: GET /proto/records
- 설명: 전체 러닝 기록을 시간 내림차순으로 반환
- 예외 처리: 기록이 없을 경우 NO_RECORDS_FOUND 예외 반환

#### ✅ 3. 특정 코스별 기록 조회
- Endpoint: GET /proto/records/{courseId}
- 설명: 특정 코스의 기록만 시간 내림차순으로 반환
- 예외 처리:
- 코스가 존재하지 않을 경우: COURSE_NOT_FOUND_FOR_RECORD
- 해당 코스 기록이 없을 경우: NO_RECORDS_FOUND 
등