### PR TITLE
Feat: [Record] 주간/월간 러닝 기록 조회 API 추가

### DIFF
--- a/runtracker/src/main/java/com/runtracker/domain/course/controller/CourseController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/controller/CourseController.java
@@ -1,7 +1,6 @@
 package com.runtracker.domain.course.controller;
 
 import com.runtracker.domain.course.dto.CourseDTO;
-import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Request;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Response;
 import com.runtracker.domain.course.service.CourseService;
@@ -54,20 +53,6 @@ public class CourseController {
             
             List<Response> courses = courseService.getNearbyCourses(request);
             return ApiResponse.ok(courses);
-        } catch (CustomException e) {
-            return ApiResponse.error(e.getResponseCode());
-        } catch (Exception e) {
-            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    @GetMapping("/{courseId}")
-    public ApiResponse<CourseDetailDTO> getCourseDetail(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable Long courseId) {
-        try {
-            CourseDetailDTO courseDetail = courseService.getCourseDetail(courseId);
-            return ApiResponse.ok(courseDetail);
         } catch (CustomException e) {
             return ApiResponse.error(e.getResponseCode());
         } catch (Exception e) {

--- a/runtracker/src/main/java/com/runtracker/domain/course/service/CourseService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/service/CourseService.java
@@ -1,13 +1,11 @@
 package com.runtracker.domain.course.service;
 
 import com.runtracker.domain.course.dto.CourseDTO;
-import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Request;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Response;
 import com.runtracker.domain.course.entity.Course;
 import com.runtracker.domain.course.entity.converter.CoordinatesConverter;
 import com.runtracker.domain.course.exception.CourseCreationFailedException;
-import com.runtracker.domain.course.exception.CourseNotFoundException;
 import com.runtracker.domain.course.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,29 +56,5 @@ public class CourseService {
                 request.getLatitude(),
                 request.getLongitude()
         );
-    }
-
-    @Transactional(readOnly = true)
-    public CourseDetailDTO getCourseDetail(Long courseId) {
-        Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new CourseNotFoundException("Course not found with id: " + courseId));
-
-        return CourseDetailDTO.builder()
-                .id(course.getId())
-                .memberId(course.getMemberId())
-                .name(course.getName())
-                .difficulty(course.getDifficulty())
-                .points(course.getPoints())
-                .startLat(course.getStartLat())
-                .startLng(course.getStartLng())
-                .distance(course.getDistance())
-                .round(course.getRound())
-                .region(course.getRegion())
-                .photo(course.getPhoto())
-                .photoLat(course.getPhotoLat())
-                .photoLng(course.getPhotoLng())
-                .createdAt(course.getCreatedAt())
-                .updatedAt(course.getUpdatedAt())
-                .build();
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
@@ -50,4 +50,18 @@ public class RecordController {
             return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @GetMapping("/week")
+    public ApiResponse<List<RecordDetailDTO>> getCoursesByWeek(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = true) @DateTimeFormat(pattern = DateConstants.DATE_PATTERN) LocalDate weekDate) {
+        try {
+            List<RecordDetailDTO> courses = recordService.getCoursesByWeek(userDetails.getMemberId(), weekDate);
+            return ApiResponse.ok(courses);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getResponseCode());
+        } catch (Exception e) {
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
@@ -1,0 +1,53 @@
+package com.runtracker.domain.record.controller;
+
+import com.runtracker.domain.record.dto.RecordDetailDTO;
+import com.runtracker.domain.record.service.RecordService;
+import com.runtracker.global.code.CommonResponseCode;
+import com.runtracker.global.code.DateConstants;
+import com.runtracker.global.exception.CustomException;
+import com.runtracker.global.response.ApiResponse;
+import com.runtracker.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/records")
+@RequiredArgsConstructor
+public class RecordController {
+    
+    private final RecordService recordService;
+
+    @GetMapping("/{courseId}")
+    public ApiResponse<RecordDetailDTO> getCourseDetail(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long courseId) {
+        try {
+            RecordDetailDTO courseDetail = recordService.getCourseDetail(courseId);
+            return ApiResponse.ok(courseDetail);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getResponseCode());
+        } catch (Exception e) {
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @GetMapping("/date")
+    public ApiResponse<List<RecordDetailDTO>> getCoursesByDateRange(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = true) @DateTimeFormat(pattern = DateConstants.DATE_PATTERN) LocalDate startDate,
+            @RequestParam(required = true) @DateTimeFormat(pattern = DateConstants.DATE_PATTERN) LocalDate endDate) {
+        try {
+            List<RecordDetailDTO> courses = recordService.getCoursesByDate(userDetails.getMemberId(), startDate, endDate);
+            return ApiResponse.ok(courses);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getResponseCode());
+        } catch (Exception e) {
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
@@ -64,4 +64,18 @@ public class RecordController {
             return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @GetMapping("/month")
+    public ApiResponse<List<RecordDetailDTO>> getCoursesByMonth(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = true) @DateTimeFormat(pattern = DateConstants.DATE_PATTERN) LocalDate monthDate) {
+        try {
+            List<RecordDetailDTO> courses = recordService.getCoursesByMonth(userDetails.getMemberId(), monthDate);
+            return ApiResponse.ok(courses);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getResponseCode());
+        } catch (Exception e) {
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/dto/RecordDetailDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/dto/RecordDetailDTO.java
@@ -1,4 +1,4 @@
-package com.runtracker.domain.course.dto;
+package com.runtracker.domain.record.dto;
 
 import com.runtracker.domain.course.enums.Difficulty;
 import com.runtracker.domain.course.entity.vo.Coordinate;
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class CourseDetailDTO {
+public class RecordDetailDTO {
     private Long id;
     private Long memberId;
     private String name;

--- a/runtracker/src/main/java/com/runtracker/domain/record/enums/RecordErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/enums/RecordErrorCode.java
@@ -1,0 +1,20 @@
+package com.runtracker.domain.record.enums;
+
+import com.runtracker.global.code.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RecordErrorCode implements ResponseCode {
+    
+    COURSE_NOT_FOUND_FOR_RECORD("RC001", "Course not found for record"),
+    INVALID_DATE_RANGE("RC002", "Start date must be before or equal to end date"),
+    DATE_RANGE_TOO_LARGE("RC003", "Date range cannot exceed 365 days"),
+    FUTURE_DATE_NOT_ALLOWED("RC004", "Future dates are not allowed"),
+    DATE_PARAMETER_REQUIRED("RC005", "Date parameters are required"),
+    NO_RECORDS_FOUND("RC006", "No records found for the specified date range");
+    
+    private final String statusCode;
+    private final String message;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/exception/CourseNotFoundForRecordException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/exception/CourseNotFoundForRecordException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.record.exception;
+
+import com.runtracker.domain.record.enums.RecordErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CourseNotFoundForRecordException extends CustomException {
+    public CourseNotFoundForRecordException() {
+        super(RecordErrorCode.COURSE_NOT_FOUND_FOR_RECORD);
+    }
+
+    public CourseNotFoundForRecordException(String message) {
+        super(RecordErrorCode.COURSE_NOT_FOUND_FOR_RECORD, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/exception/DateParameterRequiredException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/exception/DateParameterRequiredException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.record.exception;
+
+import com.runtracker.domain.record.enums.RecordErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class DateParameterRequiredException extends CustomException {
+    public DateParameterRequiredException() {
+        super(RecordErrorCode.DATE_PARAMETER_REQUIRED);
+    }
+
+    public DateParameterRequiredException(String message) {
+        super(RecordErrorCode.DATE_PARAMETER_REQUIRED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/exception/DateRangeTooLargeException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/exception/DateRangeTooLargeException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.record.exception;
+
+import com.runtracker.domain.record.enums.RecordErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class DateRangeTooLargeException extends CustomException {
+    public DateRangeTooLargeException() {
+        super(RecordErrorCode.DATE_RANGE_TOO_LARGE);
+    }
+
+    public DateRangeTooLargeException(String message) {
+        super(RecordErrorCode.DATE_RANGE_TOO_LARGE, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/exception/FutureDateNotAllowedException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/exception/FutureDateNotAllowedException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.record.exception;
+
+import com.runtracker.domain.record.enums.RecordErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class FutureDateNotAllowedException extends CustomException {
+    public FutureDateNotAllowedException() {
+        super(RecordErrorCode.FUTURE_DATE_NOT_ALLOWED);
+    }
+
+    public FutureDateNotAllowedException(String message) {
+        super(RecordErrorCode.FUTURE_DATE_NOT_ALLOWED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/exception/InvalidDateRangeException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/exception/InvalidDateRangeException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.record.exception;
+
+import com.runtracker.domain.record.enums.RecordErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class InvalidDateRangeException extends CustomException {
+    public InvalidDateRangeException() {
+        super(RecordErrorCode.INVALID_DATE_RANGE);
+    }
+
+    public InvalidDateRangeException(String message) {
+        super(RecordErrorCode.INVALID_DATE_RANGE, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/exception/NoRecordsFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/exception/NoRecordsFoundException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.record.exception;
+
+import com.runtracker.domain.record.enums.RecordErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class NoRecordsFoundException extends CustomException {
+    public NoRecordsFoundException() {
+        super(RecordErrorCode.NO_RECORDS_FOUND);
+    }
+
+    public NoRecordsFoundException(String message) {
+        super(RecordErrorCode.NO_RECORDS_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
@@ -1,0 +1,19 @@
+package com.runtracker.domain.record.repository;
+
+import com.runtracker.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface RecordRepository extends JpaRepository<Course, Long> {
+    
+    @Query("SELECT c FROM Course c WHERE c.memberId = :memberId AND DATE(c.createdAt) BETWEEN :startDate AND :endDate ORDER BY c.createdAt DESC")
+    List<Course> findByMemberIdAndCreatedAtBetween(@Param("memberId") Long memberId, 
+                                                   @Param("startDate") LocalDate startDate, 
+                                                   @Param("endDate") LocalDate endDate);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/service/RecordService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/service/RecordService.java
@@ -1,0 +1,93 @@
+package com.runtracker.domain.record.service;
+
+import com.runtracker.domain.record.dto.RecordDetailDTO;
+import com.runtracker.domain.course.entity.Course;
+import com.runtracker.domain.record.exception.CourseNotFoundForRecordException;
+import com.runtracker.domain.record.exception.InvalidDateRangeException;
+import com.runtracker.domain.record.exception.DateRangeTooLargeException;
+import com.runtracker.domain.record.exception.FutureDateNotAllowedException;
+import com.runtracker.domain.record.exception.DateParameterRequiredException;
+import com.runtracker.domain.record.exception.NoRecordsFoundException;
+import com.runtracker.domain.record.repository.RecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecordService {
+    
+    private final RecordRepository recordRepository;
+    
+    @Transactional(readOnly = true)
+    public RecordDetailDTO getCourseDetail(Long courseId) {
+        Course course = recordRepository.findById(courseId)
+                .orElseThrow(() -> new CourseNotFoundForRecordException("Course not found with id: " + courseId));
+
+        return convertToRecordDetailDTO(course);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RecordDetailDTO> getCoursesByDate(Long memberId, LocalDate startDate, LocalDate endDate) {
+        validateDateRange(startDate, endDate);
+        
+        List<Course> courses = recordRepository.findByMemberIdAndCreatedAtBetween(memberId, startDate, endDate);
+        
+        if (courses.isEmpty()) {
+            throw new NoRecordsFoundException("No courses found for member " + memberId + " between " + startDate + " and " + endDate);
+        }
+        
+        return courses.stream()
+                .map(this::convertToRecordDetailDTO)
+                .collect(Collectors.toList());
+    }
+
+    private RecordDetailDTO convertToRecordDetailDTO(Course course) {
+        return RecordDetailDTO.builder()
+                .id(course.getId())
+                .memberId(course.getMemberId())
+                .name(course.getName())
+                .difficulty(course.getDifficulty())
+                .points(course.getPoints())
+                .startLat(course.getStartLat())
+                .startLng(course.getStartLng())
+                .distance(course.getDistance())
+                .round(course.getRound())
+                .region(course.getRegion())
+                .photo(course.getPhoto())
+                .photoLat(course.getPhotoLat())
+                .photoLng(course.getPhotoLng())
+                .createdAt(course.getCreatedAt())
+                .updatedAt(course.getUpdatedAt())
+                .build();
+    }
+
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            throw new DateParameterRequiredException("Both startDate and endDate are required");
+        }
+        
+        LocalDate today = LocalDate.now();
+
+        if (startDate.isAfter(today)) {
+            throw new FutureDateNotAllowedException("Start date cannot be in the future: " + startDate);
+        }
+        if (endDate.isAfter(today)) {
+            throw new FutureDateNotAllowedException("End date cannot be in the future: " + endDate);
+        }
+
+        if (startDate.isAfter(endDate)) {
+            throw new InvalidDateRangeException("Start date must be before or equal to end date. Start: " + startDate + ", End: " + endDate);
+        }
+
+        long daysBetween = ChronoUnit.DAYS.between(startDate, endDate);
+        if (daysBetween > 365) {
+            throw new DateRangeTooLargeException("Date range cannot exceed 365 days. Current range: " + daysBetween + " days");
+        }
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/global/exception/GlobalExceptionHandler.java
+++ b/runtracker/src/main/java/com/runtracker/global/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.validation.FieldError;
 
 @Slf4j
@@ -39,6 +40,14 @@ public class GlobalExceptionHandler {
             ? errorMessage.substring(0, errorMessage.length() - 2) 
             : "유효하지 않은 요청입니다";
             
+        return ApiResponse.error(CommonResponseCode.NOT_VALID_ERROR, message);
+    }
+    
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Object> handleMissingParameter(MissingServletRequestParameterException e) {
+        log.warn("Missing required parameter: {}", e.getMessage());
+        String message = "Missing required parameter : " + e.getParameterName();
         return ApiResponse.error(CommonResponseCode.NOT_VALID_ERROR, message);
     }
     

--- a/runtracker/src/test/java/com/runtracker/domain/course/controller/CourseControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/course/controller/CourseControllerTest.java
@@ -3,7 +3,6 @@ package com.runtracker.domain.course.controller;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.runtracker.RunTrackerDocumentApiTester;
 import com.runtracker.domain.course.dto.CourseDTO;
-import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO;
 import com.runtracker.domain.course.enums.Difficulty;
 import com.runtracker.domain.course.entity.vo.Coordinate;
@@ -14,8 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.time.LocalDateTime;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +22,6 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -234,85 +230,4 @@ class CourseControllerTest extends RunTrackerDocumentApiTester {
                 ));
     }
 
-    @Test
-    void getCourseDetailTest() throws Exception {
-        // given
-        Long courseId = 1L;
-        CourseDetailDTO mockCourseDetail = CourseDetailDTO.builder()
-                .id(courseId)
-                .memberId(2L)
-                .name("뚝섬 러닝 코스")
-                .difficulty(Difficulty.MEDIUM)
-                .points(List.of(
-                        new Coordinate(37.53, 127.066),
-                        new Coordinate(37.531, 127.067),
-                        new Coordinate(37.532, 127.068)
-                ))
-                .startLat(37.5305)
-                .startLng(127.0665)
-                .distance(7000.0)
-                .round(false)
-                .region("서울특별시 성동구")
-                .photo("https://example.com/photo2.jpg")
-                .photoLat(37.5315)
-                .photoLng(127.0675)
-                .createdAt(LocalDateTime.of(2025, 8, 9, 3, 45, 54))
-                .updatedAt(LocalDateTime.of(2025, 8, 9, 3, 45, 54))
-                .build();
-
-        given(courseService.getCourseDetail(anyLong())).willReturn(mockCourseDetail);
-
-        // JWT 토큰 Mock
-        given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
-        given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
-
-        // UserDetails Mock
-        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
-                .memberId(1L)
-                .socialId("kakao_123")
-                .roles(List.of(MemberRole.USER))
-                .build();
-        given(userDetailsService.loadUserByUsername("1")).willReturn(mockUserDetails);
-
-        // when
-        this.mockMvc.perform(get("/api/courses/{courseId}", courseId)
-                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
-                .andExpect(status().isOk())
-                .andDo(document("course-get-detail",
-                        resource(
-                                ResourceSnippetParameters.builder()
-                                        .tag("courses")
-                                        .description("코스 상세 조회")
-                                        .requestHeaders(
-                                                headerWithName("Authorization").description("엑세스 토큰")
-                                        )
-                                        .pathParameters(
-                                                parameterWithName("courseId").description("코스 ID")
-                                        )
-                                        .responseFields(
-                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
-                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
-                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
-                                                fieldWithPath("body.id").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("body.memberId").type(JsonFieldType.NUMBER).description("생성자 회원 ID"),
-                                                fieldWithPath("body.name").type(JsonFieldType.STRING).description("코스 이름"),
-                                                fieldWithPath("body.difficulty").type(JsonFieldType.STRING).description("난이도 (EASY, MEDIUM, HARD)"),
-                                                fieldWithPath("body.points").type(JsonFieldType.ARRAY).description("코스 경로 좌표 리스트"),
-                                                fieldWithPath("body.points[].lat").type(JsonFieldType.NUMBER).description("좌표 위도"),
-                                                fieldWithPath("body.points[].lnt").type(JsonFieldType.NUMBER).description("좌표 경도"),
-                                                fieldWithPath("body.startLat").type(JsonFieldType.NUMBER).description("시작 지점 위도"),
-                                                fieldWithPath("body.startLng").type(JsonFieldType.NUMBER).description("시작 지점 경도"),
-                                                fieldWithPath("body.distance").type(JsonFieldType.NUMBER).description("코스 거리 (미터)"),
-                                                fieldWithPath("body.round").type(JsonFieldType.BOOLEAN).description("왕복 여부"),
-                                                fieldWithPath("body.region").type(JsonFieldType.STRING).description("코스 지역"),
-                                                fieldWithPath("body.photo").type(JsonFieldType.STRING).description("코스 사진 URL").optional(),
-                                                fieldWithPath("body.photoLat").type(JsonFieldType.NUMBER).description("사진 촬영 위치 위도").optional(),
-                                                fieldWithPath("body.photoLng").type(JsonFieldType.NUMBER).description("사진 촬영 위치 경도").optional(),
-                                                fieldWithPath("body.createdAt").type(JsonFieldType.STRING).description("코스 생성 시간"),
-                                                fieldWithPath("body.updatedAt").type(JsonFieldType.STRING).description("코스 수정 시간")
-                                        )
-                                        .build()
-                        )
-                ));
-    }
 }

--- a/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
@@ -1,0 +1,219 @@
+package com.runtracker.domain.record.controller;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.runtracker.RunTrackerDocumentApiTester;
+import com.runtracker.domain.record.dto.RecordDetailDTO;
+import com.runtracker.domain.course.enums.Difficulty;
+import com.runtracker.domain.course.entity.vo.Coordinate;
+import com.runtracker.domain.record.service.RecordService;
+import com.runtracker.domain.member.entity.enums.MemberRole;
+import com.runtracker.global.security.UserDetailsImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RecordControllerTest extends RunTrackerDocumentApiTester {
+
+    @MockitoBean
+    private RecordService recordService;
+
+    @Test
+    void getCourseDetailTest() throws Exception {
+        // given
+        Long courseId = 1L;
+        RecordDetailDTO mockCourseDetail = RecordDetailDTO.builder()
+                .id(courseId)
+                .memberId(2L)
+                .name("뚝섬 러닝 코스")
+                .difficulty(Difficulty.MEDIUM)
+                .points(List.of(
+                        new Coordinate(37.53, 127.066),
+                        new Coordinate(37.531, 127.067)
+                ))
+                .startLat(37.5305)
+                .startLng(127.0665)
+                .distance(7000.0)
+                .round(false)
+                .region("서울특별시 성동구")
+                .photo("https://example.com/photo2.jpg")
+                .photoLat(37.5315)
+                .photoLng(127.0675)
+                .createdAt(LocalDateTime.of(2025, 8, 9, 3, 45, 54))
+                .updatedAt(LocalDateTime.of(2025, 8, 9, 3, 45, 54))
+                .build();
+
+        given(recordService.getCourseDetail(anyLong())).willReturn(mockCourseDetail);
+
+        // JWT 토큰 Mock
+        given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
+        given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
+
+        // UserDetails Mock
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(1L)
+                .socialId("kakao_123")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("1")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(get("/api/records/{courseId}", courseId)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("record-get-course-detail",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("records")
+                                        .description("코스별 러닝 기록 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("courseId").description("코스 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body.id").type(JsonFieldType.NUMBER).description("코스 ID"),
+                                                fieldWithPath("body.memberId").type(JsonFieldType.NUMBER).description("생성자 회원 ID"),
+                                                fieldWithPath("body.name").type(JsonFieldType.STRING).description("코스 이름"),
+                                                fieldWithPath("body.difficulty").type(JsonFieldType.STRING).description("난이도 (EASY, MEDIUM, HARD)"),
+                                                fieldWithPath("body.points").type(JsonFieldType.ARRAY).description("코스 경로 좌표 리스트"),
+                                                fieldWithPath("body.points[].lat").type(JsonFieldType.NUMBER).description("좌표 위도"),
+                                                fieldWithPath("body.points[].lnt").type(JsonFieldType.NUMBER).description("좌표 경도"),
+                                                fieldWithPath("body.startLat").type(JsonFieldType.NUMBER).description("시작 지점 위도"),
+                                                fieldWithPath("body.startLng").type(JsonFieldType.NUMBER).description("시작 지점 경도"),
+                                                fieldWithPath("body.distance").type(JsonFieldType.NUMBER).description("코스 거리 (미터)"),
+                                                fieldWithPath("body.round").type(JsonFieldType.BOOLEAN).description("왕복 여부"),
+                                                fieldWithPath("body.region").type(JsonFieldType.STRING).description("코스 지역"),
+                                                fieldWithPath("body.photo").type(JsonFieldType.STRING).description("코스 사진 URL").optional(),
+                                                fieldWithPath("body.photoLat").type(JsonFieldType.NUMBER).description("사진 촬영 위치 위도").optional(),
+                                                fieldWithPath("body.photoLng").type(JsonFieldType.NUMBER).description("사진 촬영 위치 경도").optional(),
+                                                fieldWithPath("body.createdAt").type(JsonFieldType.STRING).description("코스 생성 시간"),
+                                                fieldWithPath("body.updatedAt").type(JsonFieldType.STRING).description("코스 수정 시간")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void getCoursesByDateRangeTest() throws Exception {
+        // given
+        List<RecordDetailDTO> mockCourses = List.of(
+                RecordDetailDTO.builder()
+                        .id(1L)
+                        .memberId(1L)
+                        .name("한강 러닝 코스")
+                        .difficulty(Difficulty.EASY)
+                        .points(List.of(
+                                new Coordinate(37.5512, 126.9882),
+                                new Coordinate(37.5523, 126.9891)
+                        ))
+                        .startLat(37.5512)
+                        .startLng(126.9882)
+                        .distance(3000.0)
+                        .round(false)
+                        .region("서울특별시 중구")
+                        .photo("https://example.com/photo1.jpg")
+                        .photoLat(37.5515)
+                        .photoLng(126.9885)
+                        .createdAt(LocalDateTime.of(2025, 8, 9, 10, 0, 0))
+                        .updatedAt(LocalDateTime.of(2025, 8, 9, 10, 0, 0))
+                        .build(),
+                RecordDetailDTO.builder()
+                        .id(2L)
+                        .memberId(1L)
+                        .name("뚝섬 러닝 코스")
+                        .difficulty(Difficulty.MEDIUM)
+                        .points(List.of(
+                                new Coordinate(37.53, 127.066),
+                                new Coordinate(37.531, 127.067)
+                        ))
+                        .startLat(37.5305)
+                        .startLng(127.0665)
+                        .distance(5000.0)
+                        .round(true)
+                        .region("서울특별시 성동구")
+                        .photo("https://example.com/photo2.jpg")
+                        .photoLat(37.5315)
+                        .photoLng(127.0675)
+                        .createdAt(LocalDateTime.of(2025, 8, 10, 14, 30, 0))
+                        .updatedAt(LocalDateTime.of(2025, 8, 10, 14, 30, 0))
+                        .build()
+        );
+
+        given(recordService.getCoursesByDate(anyLong(), any(), any())).willReturn(mockCourses);
+
+        // JWT 토큰 Mock
+        given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
+        given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
+
+        // UserDetails Mock
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(1L)
+                .socialId("kakao_123")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("1")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(get("/api/records/date")
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN)
+                        .param("startDate", "2025-08-09")
+                        .param("endDate", "2025-08-10"))
+                .andExpect(status().isOk())
+                .andDo(document("record-get-courses-by-date-range",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("records")
+                                        .description("날짜 범위로 러닝 기록(코스) 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .queryParameters(
+                                                parameterWithName("startDate").description("시작 날짜 (YYYY-MM-DD)"),
+                                                parameterWithName("endDate").description("종료 날짜 (YYYY-MM-DD)")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.ARRAY).description("코스 목록"),
+                                                fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("코스 ID"),
+                                                fieldWithPath("body[].memberId").type(JsonFieldType.NUMBER).description("생성자 회원 ID"),
+                                                fieldWithPath("body[].name").type(JsonFieldType.STRING).description("코스 이름"),
+                                                fieldWithPath("body[].difficulty").type(JsonFieldType.STRING).description("난이도 (EASY, MEDIUM, HARD)"),
+                                                fieldWithPath("body[].points").type(JsonFieldType.ARRAY).description("코스 경로 좌표 리스트"),
+                                                fieldWithPath("body[].points[].lat").type(JsonFieldType.NUMBER).description("좌표 위도"),
+                                                fieldWithPath("body[].points[].lnt").type(JsonFieldType.NUMBER).description("좌표 경도"),
+                                                fieldWithPath("body[].startLat").type(JsonFieldType.NUMBER).description("시작 지점 위도"),
+                                                fieldWithPath("body[].startLng").type(JsonFieldType.NUMBER).description("시작 지점 경도"),
+                                                fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("코스 거리 (미터)"),
+                                                fieldWithPath("body[].round").type(JsonFieldType.BOOLEAN).description("왕복 여부"),
+                                                fieldWithPath("body[].region").type(JsonFieldType.STRING).description("코스 지역"),
+                                                fieldWithPath("body[].photo").type(JsonFieldType.STRING).description("코스 사진 URL").optional(),
+                                                fieldWithPath("body[].photoLat").type(JsonFieldType.NUMBER).description("사진 촬영 위치 위도").optional(),
+                                                fieldWithPath("body[].photoLng").type(JsonFieldType.NUMBER).description("사진 촬영 위치 경도").optional(),
+                                                fieldWithPath("body[].createdAt").type(JsonFieldType.STRING).description("코스 생성 시간"),
+                                                fieldWithPath("body[].updatedAt").type(JsonFieldType.STRING).description("코스 수정 시간")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+}

--- a/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
@@ -216,4 +216,108 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                         )
                 ));
     }
+
+    @Test
+    void getCoursesByWeekTest() throws Exception {
+        // given
+        List<RecordDetailDTO> mockCourses = List.of(
+                RecordDetailDTO.builder()
+                        .id(1L)
+                        .memberId(1L)
+                        .name("올림픽공원 러닝 코스")
+                        .difficulty(Difficulty.EASY)
+                        .points(List.of(
+                                new Coordinate(37.5197, 127.1154),
+                                new Coordinate(37.5203, 127.1165)
+                        ))
+                        .startLat(37.5197)
+                        .startLng(127.1154)
+                        .distance(4000.0)
+                        .round(true)
+                        .region("서울특별시 송파구")
+                        .photo("https://example.com/photo3.jpg")
+                        .photoLat(37.5200)
+                        .photoLng(127.1160)
+                        .createdAt(LocalDateTime.of(2025, 8, 11, 8, 0, 0))
+                        .updatedAt(LocalDateTime.of(2025, 8, 11, 8, 0, 0))
+                        .build(),
+                RecordDetailDTO.builder()
+                        .id(2L)
+                        .memberId(1L)
+                        .name("청계천 러닝 코스")
+                        .difficulty(Difficulty.MEDIUM)
+                        .points(List.of(
+                                new Coordinate(37.5658, 126.9784),
+                                new Coordinate(37.5665, 126.9795)
+                        ))
+                        .startLat(37.5658)
+                        .startLng(126.9784)
+                        .distance(6000.0)
+                        .round(false)
+                        .region("서울특별시 중구")
+                        .photo("https://example.com/photo4.jpg")
+                        .photoLat(37.5662)
+                        .photoLng(126.9790)
+                        .createdAt(LocalDateTime.of(2025, 8, 12, 18, 30, 0))
+                        .updatedAt(LocalDateTime.of(2025, 8, 12, 18, 30, 0))
+                        .build()
+        );
+
+        given(recordService.getCoursesByWeek(anyLong(), any())).willReturn(mockCourses);
+
+        // JWT 토큰 Mock
+        given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
+        given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
+
+        // UserDetails Mock
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(1L)
+                .socialId("kakao_123")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("1")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(get("/api/records/week")
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN)
+                        .param("weekDate", "2025-08-11"))
+                .andExpect(status().isOk())
+                .andDo(document("record-get-courses-by-week",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("records")
+                                        .description("주 범위로 러닝 기록(코스) 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .queryParameters(
+                                                parameterWithName("weekDate").description("주간 기준 날짜 (YYYY-MM-DD) - 해당 날짜가 포함된 주(월~일)의 기록을 조회")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.ARRAY).description("코스 목록"),
+                                                fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("코스 ID"),
+                                                fieldWithPath("body[].memberId").type(JsonFieldType.NUMBER).description("생성자 회원 ID"),
+                                                fieldWithPath("body[].name").type(JsonFieldType.STRING).description("코스 이름"),
+                                                fieldWithPath("body[].difficulty").type(JsonFieldType.STRING).description("난이도 (EASY, MEDIUM, HARD)"),
+                                                fieldWithPath("body[].points").type(JsonFieldType.ARRAY).description("코스 경로 좌표 리스트"),
+                                                fieldWithPath("body[].points[].lat").type(JsonFieldType.NUMBER).description("좌표 위도"),
+                                                fieldWithPath("body[].points[].lnt").type(JsonFieldType.NUMBER).description("좌표 경도"),
+                                                fieldWithPath("body[].startLat").type(JsonFieldType.NUMBER).description("시작 지점 위도"),
+                                                fieldWithPath("body[].startLng").type(JsonFieldType.NUMBER).description("시작 지점 경도"),
+                                                fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("코스 거리 (미터)"),
+                                                fieldWithPath("body[].round").type(JsonFieldType.BOOLEAN).description("왕복 여부"),
+                                                fieldWithPath("body[].region").type(JsonFieldType.STRING).description("코스 지역"),
+                                                fieldWithPath("body[].photo").type(JsonFieldType.STRING).description("코스 사진 URL").optional(),
+                                                fieldWithPath("body[].photoLat").type(JsonFieldType.NUMBER).description("사진 촬영 위치 위도").optional(),
+                                                fieldWithPath("body[].photoLng").type(JsonFieldType.NUMBER).description("사진 촬영 위치 경도").optional(),
+                                                fieldWithPath("body[].createdAt").type(JsonFieldType.STRING).description("코스 생성 시간"),
+                                                fieldWithPath("body[].updatedAt").type(JsonFieldType.STRING).description("코스 수정 시간")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
 }

--- a/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
@@ -56,12 +56,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 .build();
 
         given(recordService.getCourseDetail(anyLong())).willReturn(mockCourseDetail);
-
-        // JWT 토큰 Mock
         given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
         given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
 
-        // UserDetails Mock
         UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
                 .memberId(1L)
                 .socialId("kakao_123")
@@ -158,12 +155,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
         );
 
         given(recordService.getCoursesByDate(anyLong(), any(), any())).willReturn(mockCourses);
-
-        // JWT 토큰 Mock
         given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
         given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
 
-        // UserDetails Mock
         UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
                 .memberId(1L)
                 .socialId("kakao_123")
@@ -264,12 +258,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
         );
 
         given(recordService.getCoursesByWeek(anyLong(), any())).willReturn(mockCourses);
-
-        // JWT 토큰 Mock
         given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
         given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
 
-        // UserDetails Mock
         UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
                 .memberId(1L)
                 .socialId("kakao_123")
@@ -292,6 +283,107 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                                         )
                                         .queryParameters(
                                                 parameterWithName("weekDate").description("주간 기준 날짜 (YYYY-MM-DD) - 해당 날짜가 포함된 주(월~일)의 기록을 조회")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.ARRAY).description("코스 목록"),
+                                                fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("코스 ID"),
+                                                fieldWithPath("body[].memberId").type(JsonFieldType.NUMBER).description("생성자 회원 ID"),
+                                                fieldWithPath("body[].name").type(JsonFieldType.STRING).description("코스 이름"),
+                                                fieldWithPath("body[].difficulty").type(JsonFieldType.STRING).description("난이도 (EASY, MEDIUM, HARD)"),
+                                                fieldWithPath("body[].points").type(JsonFieldType.ARRAY).description("코스 경로 좌표 리스트"),
+                                                fieldWithPath("body[].points[].lat").type(JsonFieldType.NUMBER).description("좌표 위도"),
+                                                fieldWithPath("body[].points[].lnt").type(JsonFieldType.NUMBER).description("좌표 경도"),
+                                                fieldWithPath("body[].startLat").type(JsonFieldType.NUMBER).description("시작 지점 위도"),
+                                                fieldWithPath("body[].startLng").type(JsonFieldType.NUMBER).description("시작 지점 경도"),
+                                                fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("코스 거리 (미터)"),
+                                                fieldWithPath("body[].round").type(JsonFieldType.BOOLEAN).description("왕복 여부"),
+                                                fieldWithPath("body[].region").type(JsonFieldType.STRING).description("코스 지역"),
+                                                fieldWithPath("body[].photo").type(JsonFieldType.STRING).description("코스 사진 URL").optional(),
+                                                fieldWithPath("body[].photoLat").type(JsonFieldType.NUMBER).description("사진 촬영 위치 위도").optional(),
+                                                fieldWithPath("body[].photoLng").type(JsonFieldType.NUMBER).description("사진 촬영 위치 경도").optional(),
+                                                fieldWithPath("body[].createdAt").type(JsonFieldType.STRING).description("코스 생성 시간"),
+                                                fieldWithPath("body[].updatedAt").type(JsonFieldType.STRING).description("코스 수정 시간")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void getCoursesByMonthTest() throws Exception {
+        // given
+        List<RecordDetailDTO> mockCourses = List.of(
+                RecordDetailDTO.builder()
+                        .id(1L)
+                        .memberId(1L)
+                        .name("남산 러닝 코스")
+                        .difficulty(Difficulty.HARD)
+                        .points(List.of(
+                                new Coordinate(37.5512, 126.9910),
+                                new Coordinate(37.5520, 126.9920)
+                        ))
+                        .startLat(37.5512)
+                        .startLng(126.9910)
+                        .distance(8000.0)
+                        .round(true)
+                        .region("서울특별시 중구")
+                        .photo("https://example.com/photo5.jpg")
+                        .photoLat(37.5516)
+                        .photoLng(126.9915)
+                        .createdAt(LocalDateTime.of(2025, 8, 5, 7, 0, 0))
+                        .updatedAt(LocalDateTime.of(2025, 8, 5, 7, 0, 0))
+                        .build(),
+                RecordDetailDTO.builder()
+                        .id(2L)
+                        .memberId(1L)
+                        .name("잠실 러닝 코스")
+                        .difficulty(Difficulty.MEDIUM)
+                        .points(List.of(
+                                new Coordinate(37.5145, 127.1025),
+                                new Coordinate(37.5155, 127.1035)
+                        ))
+                        .startLat(37.5145)
+                        .startLng(127.1025)
+                        .distance(5500.0)
+                        .round(false)
+                        .region("서울특별시 송파구")
+                        .photo("https://example.com/photo6.jpg")
+                        .photoLat(37.5150)
+                        .photoLng(127.1030)
+                        .createdAt(LocalDateTime.of(2025, 8, 25, 19, 0, 0))
+                        .updatedAt(LocalDateTime.of(2025, 8, 25, 19, 0, 0))
+                        .build()
+        );
+
+        given(recordService.getCoursesByMonth(anyLong(), any())).willReturn(mockCourses);
+        given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
+        given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(1L)
+                .socialId("kakao_123")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("1")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(get("/api/records/month")
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN)
+                        .param("monthDate", "2025-08-15"))
+                .andExpect(status().isOk())
+                .andDo(document("record-get-courses-by-month",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("records")
+                                        .description("월별 러닝 기록(코스) 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .queryParameters(
+                                                parameterWithName("monthDate").description("월간 기준 날짜 (YYYY-MM-DD) - 해당 날짜가 포함된 월의 기록을 조회")
                                         )
                                         .responseFields(
                                                 fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),


### PR DESCRIPTION
## Summary
- 코스별 러닝 기록 조회 엔드포인트 추가 (/api/records/{courseId})
- 날짜 범위 러닝 기록 조회 엔드포인트 추가 (/api/records/date)
- 주간 기록 조회 엔드포인트 추가 (/api/records/week)
- 월간 기록 조회 엔드포인트 추가 (/api/records/month)
- 포괄적인 날짜 검증 및 예외 처리 시스템 구현

## 주요 변경사항
- RecordController: 4개 조회 엔드포인트 추가
- RecordService: 각 조회 타입별 비즈니스 로직 및 검증 구현
- Exception 처리: Record 도메인 전용 에러 코드 및 예외 클래스 생성
- 유틸리티 메서드: 주간/월간 시작일/종료일 계산 함수 추가
- GlobalExceptionHandler: 누락된 파라미터 예외 처리 추가
- 테스트: Spring REST Docs 포함 테스트 케이스 작성

### API 명세

#### 코스별 조회
- GET /api/records/{courseId}
- 특정 코스 ID로 러닝 기록 상세 조회

#### 날짜 범위 조회
- GET /api/records/date?startDate=2025-08-09&endDate=2025-08-10
- 시작일~종료일 범위의 기록 조회 (최대 365일)

#### 주간 조회
- GET /api/records/week?weekDate=2025-08-15
- 해당 날짜가 포함된 주(월~일)의 기록 조회

#### 월간 조회
- GET /api/records/month?monthDate=2025-08-15
- 해당 날짜가 포함된 월의 기록 조회

### 예외 처리
- 미래 날짜 입력 방지
- 날짜 범위 초과 검증 (365일 제한)
- 시작일 > 종료일 검증
- 필수 파라미터 누락 처리
- 조회 결과 없음 처리