### PR TITLE
Feat: [Member] 레디스 설정 및 로그아웃, 회원 탈퇴 api 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,24 @@ jobs:
           MYSQL_USER: testuser                  
           MYSQL_PASSWORD: testpass              
         options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=5
+      
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     env:
       SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/runtracker_test
       SPRING_DATASOURCE_USERNAME: testuser
       SPRING_DATASOURCE_PASSWORD: testpass
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_PORT: ${{ secrets.REDIS_PORT }}
       KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
       KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/runtracker/build.gradle
+++ b/runtracker/build.gradle
@@ -27,6 +27,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/runtracker/src/main/java/com/runtracker/domain/course/repository/CourseRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/repository/CourseRepository.java
@@ -6,4 +6,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long>, CourseRepositoryCustom {
+    
+    /**
+     * 특정 회원의 모든 코스 삭제
+     */
+    void deleteByMemberId(Long memberId);
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
@@ -48,4 +48,10 @@ public class MemberController {
         memberService.logout(userDetails.getMemberId());
         return ApiResponse.ok();
     }
+
+    @DeleteMapping("/withdrawal")
+    public ApiResponse<Void> withdrawMember(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        memberService.withdrawMember(userDetails.getMemberId());
+        return ApiResponse.ok();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
@@ -5,8 +5,10 @@ import com.runtracker.domain.member.service.MemberService;
 import com.runtracker.domain.member.service.AuthService;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import com.runtracker.global.response.ApiResponse;
+import com.runtracker.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
@@ -39,5 +41,11 @@ public class MemberController {
     @PostMapping("/test-login")
     public ApiResponse<LoginTokenDto> testLogin(@Valid @RequestBody LoginTokenDto.SocialIdLoginRequest request) {
         return ApiResponse.ok(authService.testLoginBySocialId(request.getSocialId(), request.getKey()));
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        memberService.logout(userDetails.getMemberId());
+        return ApiResponse.ok();
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/enums/MemberErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/enums/MemberErrorCode.java
@@ -1,0 +1,16 @@
+package com.runtracker.domain.member.enums;
+
+import com.runtracker.global.code.ResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ResponseCode {
+
+    MEMBER_NOT_FOUND("M001", "Member not found"),
+    MEMBER_WITHDRAWAL_FAILED("M002", "Member withdrawal failed");
+
+    private final String statusCode;
+    private final String message;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/exception/MemberNotFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,15 @@
+package com.runtracker.domain.member.exception;
+
+import com.runtracker.domain.member.enums.MemberErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class MemberNotFoundException extends CustomException {
+
+    public MemberNotFoundException() {
+        super(MemberErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    public MemberNotFoundException(String message) {
+        super(MemberErrorCode.MEMBER_NOT_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/exception/MemberWithdrawalFailedException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/exception/MemberWithdrawalFailedException.java
@@ -1,0 +1,15 @@
+package com.runtracker.domain.member.exception;
+
+import com.runtracker.domain.member.enums.MemberErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class MemberWithdrawalFailedException extends CustomException {
+
+    public MemberWithdrawalFailedException() {
+        super(MemberErrorCode.MEMBER_WITHDRAWAL_FAILED);
+    }
+
+    public MemberWithdrawalFailedException(String message) {
+        super(MemberErrorCode.MEMBER_WITHDRAWAL_FAILED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
@@ -3,10 +3,13 @@ package com.runtracker.domain.member.service;
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.repository.MemberRepository;
+import com.runtracker.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Optional;
 
@@ -17,6 +20,7 @@ import java.util.Optional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
 
     @Transactional
     public Member createOrUpdateMember(String socialAttr, String socialId, 
@@ -62,5 +66,22 @@ public class MemberService {
                 .userId(member.getId())
                 .socialId(member.getSocialId())
                 .build();
+    }
+
+    @Transactional
+    public void logout(Long memberId) {
+        // 현재 요청에서 토큰 추출
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            String authHeader = attributes.getRequest().getHeader("Authorization");
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                String token = authHeader.substring(7);
+                try {
+                    jwtUtil.blacklistToken(token);
+                } catch (Exception e) {
+                    log.error("Failed to blacklist token for user: {}", memberId, e);
+                }
+            }
+        }
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
@@ -3,6 +3,8 @@ package com.runtracker.domain.member.service;
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.repository.MemberRepository;
+import com.runtracker.domain.course.repository.CourseRepository;
+import com.runtracker.domain.member.exception.MemberNotFoundException;
 import com.runtracker.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +22,7 @@ import java.util.Optional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final CourseRepository courseRepository;
     private final JwtUtil jwtUtil;
 
     @Transactional
@@ -48,12 +51,12 @@ public class MemberService {
 
     public Member getMemberByName(String name) {
         return memberRepository.findByName(name)
-                .orElseThrow(() -> new RuntimeException("Member not found with name: " + name));
+                .orElseThrow(() -> new MemberNotFoundException("Member not found with name: " + name));
     }
 
     public Member getMemberBySocialId(String socialId) {
         return memberRepository.findBySocialId(socialId)
-                .orElseThrow(() -> new RuntimeException("Member not found with socialId: " + socialId));
+                .orElseThrow(() -> new MemberNotFoundException("Member not found with socialId: " + socialId));
     }
 
     @Transactional(readOnly = true)
@@ -83,5 +86,27 @@ public class MemberService {
                 }
             }
         }
+    }
+
+    @Transactional
+    public void withdrawMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("Member not found with id: " + memberId));
+
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            String authHeader = attributes.getRequest().getHeader("Authorization");
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                String token = authHeader.substring(7);
+                try {
+                    jwtUtil.blacklistToken(token);
+                } catch (Exception e) {
+                    log.error("Failed to blacklist token for withdrawing user: {}", memberId, e);
+                }
+            }
+        }
+
+        courseRepository.deleteByMemberId(memberId);
+        memberRepository.delete(member);
     }
 }

--- a/runtracker/src/main/java/com/runtracker/global/config/RedisConfig.java
+++ b/runtracker/src/main/java/com/runtracker/global/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.runtracker.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${REDIS_HOST}")
+    private String redisHost;
+
+    @Value("${REDIS_PORT}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        
+        return redisTemplate;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/global/jwt/service/TokenBlacklistService.java
+++ b/runtracker/src/main/java/com/runtracker/global/jwt/service/TokenBlacklistService.java
@@ -1,0 +1,61 @@
+package com.runtracker.global.jwt.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String BLACKLIST_PREFIX = "blacklist:token:";
+
+    /**
+     * 토큰을 블랙리스트에 추가
+     */
+    public void blacklistToken(String token, long expirationTime) {
+        try {
+            long currentTime = System.currentTimeMillis();
+            long remainingTime = expirationTime - currentTime;
+            
+            if (remainingTime > 0) {
+                String key = BLACKLIST_PREFIX + token;
+                Duration ttl = Duration.ofMillis(remainingTime);
+                redisTemplate.opsForValue().set(key, "blacklisted", ttl);
+                log.info("Token blacklisted successfully with TTL: {} ms", remainingTime);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to blacklist token", e);
+        }
+    }
+
+    /**
+     * 토큰이 블랙리스트에 있는지 확인
+     */
+    public boolean isBlacklisted(String token) {
+        try {
+            String key = BLACKLIST_PREFIX + token;
+            return redisTemplate.hasKey(key);
+        } catch (Exception e) {
+            log.error("Failed to check token blacklist status", e);
+            return false;
+        }
+    }
+
+    /**
+     * 특정 토큰을 블랙리스트에서 제거 (테스트용)
+     */
+    public void removeFromBlacklist(String token) {
+        try {
+            String key = BLACKLIST_PREFIX + token;
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.error("Failed to remove token from blacklist", e);
+        }
+    }
+}

--- a/runtracker/src/main/resources/application.yml
+++ b/runtracker/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   security:
     oauth2:
       client:

--- a/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
@@ -12,10 +12,14 @@ import java.util.Map;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberControllerTest extends RunTrackerDocumentApiTester {
@@ -143,6 +147,62 @@ class MemberControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("body.tokenData.refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰"),
                                                 fieldWithPath("body.tokenData.accessTokenExpiredAt").type(JsonFieldType.NUMBER).description("액세스 토큰 만료 시간 (timestamp)"),
                                                 fieldWithPath("body.tokenData.refreshTokenExpiredAt").type(JsonFieldType.NUMBER).description("리프레시 토큰 만료 시간 (timestamp)")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void logoutTest() throws Exception {
+        // given
+        doNothing().when(memberService).logout(anyLong());
+
+        // when & then
+        this.mockMvc.perform(post("/api/members/logout")
+                        .header("Authorization", "Bearer access_token_example"))
+                .andExpect(status().isOk())
+                .andDo(document("member-logout",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("users")
+                                        .description("로그아웃")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("Bearer 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.NULL).description("응답 본문 (null)").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void withdrawMemberTest() throws Exception {
+        // given
+        doNothing().when(memberService).withdrawMember(anyLong());
+
+        // when & then
+        this.mockMvc.perform(delete("/api/members/withdrawal")
+                        .header("Authorization", "Bearer access_token_example"))
+                .andExpect(status().isOk())
+                .andDo(document("member-withdrawal",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("users")
+                                        .description("회원 탈퇴")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("Bearer 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.NULL).description("응답 본문 (null)").optional()
                                         )
                                         .build()
                         )


### PR DESCRIPTION
## Summary
JWT 토큰 블랙리스트 기반 로그아웃 및 회원탈퇴 기능 구현

## Changes

### Features
- **로그아웃 API 구현** (`POST /api/members/logout`)
   - JWT 토큰을 Redis 블랙리스트에 등록하여 즉시 무효화
   - Authorization 헤더에서 자동으로 토큰 추출 및 처리
- **회원탈퇴 API 구현** (`DELETE /api/members/withdrawal`)
   - 현재 토큰 무효화 + 연관 데이터 삭제 + 회원 정보 삭제
   - 코스 등 회원이 생성한 모든 데이터 자동 삭제
- **JWT 토큰 블랙리스트 시스템**
   - Redis 기반 토큰 블랙리스트 관리
   - TTL 설정으로 만료된 토큰 자동 정리
   - JwtUtil에 블랙리스트 검증 로직 통합