### PR TITLE
Feat: [Crew] 크루 생성 및 관리 api 구현

### DIFF
--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -88,4 +88,15 @@ public class CrewController {
         
         return ApiResponse.ok();
     }
+    
+    @DeleteMapping("/delete/{crewId}")
+    public ApiResponse<Void> deleteCrew(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        Long leaderId = userDetails.getMemberId();
+        crewService.deleteCrew(crewId, leaderId);
+        
+        return ApiResponse.ok();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -27,4 +27,15 @@ public class CrewController {
         
         return ApiResponse.ok();
     }
+    
+    @PostMapping("/join/{crewId}")
+    public ApiResponse<Void> applyToJoinCrew(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        Long applicantId = userDetails.getMemberId();
+        crewService.applyToJoinCrew(crewId, applicantId);
+        
+        return ApiResponse.ok();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -3,6 +3,7 @@ package com.runtracker.domain.crew.controller;
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
 import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
+import com.runtracker.domain.crew.dto.CrewUpdateDTO;
 import com.runtracker.domain.crew.service.CrewService;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -72,6 +73,18 @@ public class CrewController {
         
         Long managerId = userDetails.getMemberId();
         crewService.updateCrewMemberRole(crewId, request, managerId);
+        
+        return ApiResponse.ok();
+    }
+    
+    @PatchMapping("/update/{crewId}")
+    public ApiResponse<Void> updateCrew(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @RequestBody CrewUpdateDTO.Request request) {
+        
+        Long leaderId = userDetails.getMemberId();
+        crewService.updateCrew(crewId, request, leaderId);
         
         return ApiResponse.ok();
     }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -2,8 +2,12 @@ package com.runtracker.domain.crew.controller;
 
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
+import com.runtracker.domain.crew.dto.CrewDetailDTO;
+import com.runtracker.domain.crew.dto.CrewListDTO;
+import com.runtracker.domain.crew.dto.CrewManagementDTO;
 import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
 import com.runtracker.domain.crew.dto.CrewUpdateDTO;
+import com.runtracker.domain.crew.dto.MemberProfileDTO;
 import com.runtracker.domain.crew.service.CrewService;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -121,5 +125,57 @@ public class CrewController {
         crewService.leaveCrew(crewId, memberId);
         
         return ApiResponse.ok();
+    }
+    
+    @GetMapping("/list")
+    public ApiResponse<CrewListDTO.ListResponse> getCrewList(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        
+        Long memberId = userDetails.getMemberId();
+        CrewListDTO.ListResponse response = crewService.getAllCrews();
+        return ApiResponse.ok(response);
+    }
+    
+    @GetMapping("/{crewId}")
+    public ApiResponse<CrewDetailDTO.Response> getCrewDetail(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        Long memberId = userDetails.getMemberId();
+        CrewDetailDTO.Response response = crewService.getCrewDetail(crewId);
+        return ApiResponse.ok(response);
+    }
+    
+    @GetMapping("/list/pending/{crewId}")
+    public ApiResponse<CrewManagementDTO.PendingMembersResponse> getPendingMembers(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        Long managerId = userDetails.getMemberId();
+        CrewManagementDTO.PendingMembersResponse response = crewService.getPendingMembers(crewId, managerId);
+        
+        return ApiResponse.ok(response);
+    }
+    
+    @GetMapping("/list/banned/{crewId}")
+    public ApiResponse<CrewManagementDTO.BannedMembersResponse> getBannedMembers(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        Long managerId = userDetails.getMemberId();
+        CrewManagementDTO.BannedMembersResponse response = crewService.getBannedMembers(crewId, managerId);
+        
+        return ApiResponse.ok(response);
+    }
+    
+    @GetMapping("/member/{memberId}")
+    public ApiResponse<MemberProfileDTO> getMemberProfile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long memberId) {
+        
+        Long requesterId = userDetails.getMemberId();
+        MemberProfileDTO response = crewService.getMemberProfile(memberId, requesterId);
+        
+        return ApiResponse.ok(response);
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -2,6 +2,7 @@ package com.runtracker.domain.crew.controller;
 
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
+import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
 import com.runtracker.domain.crew.service.CrewService;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -59,6 +60,18 @@ public class CrewController {
         
         Long leaderId = userDetails.getMemberId();
         crewService.processJoinRequest(crewId, request, leaderId);
+        
+        return ApiResponse.ok();
+    }
+    
+    @PostMapping("/member/role/{crewId}")
+    public ApiResponse<Void> updateCrewMemberRole(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @RequestBody CrewMemberUpdateDTO.Request request) {
+        
+        Long managerId = userDetails.getMemberId();
+        crewService.updateCrewMemberRole(crewId, request, managerId);
         
         return ApiResponse.ok();
     }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -38,4 +38,15 @@ public class CrewController {
         
         return ApiResponse.ok();
     }
+    
+    @PostMapping("/join/cancel/{crewId}")
+    public ApiResponse<Void> cancelCrewApplication(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        Long applicantId = userDetails.getMemberId();
+        crewService.cancelCrewApplication(crewId, applicantId);
+        
+        return ApiResponse.ok();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -1,5 +1,6 @@
 package com.runtracker.domain.crew.controller;
 
+import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
 import com.runtracker.domain.crew.service.CrewService;
 import com.runtracker.global.response.ApiResponse;
@@ -19,8 +20,8 @@ public class CrewController {
 
     @PostMapping("/create")
     public ApiResponse<Void> createCrew(
-            @RequestBody CrewCreateDTO.Request request,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody CrewCreateDTO.Request request) {
         
         Long leaderId = userDetails.getMemberId();
         crewService.createCrew(request, leaderId);
@@ -33,8 +34,8 @@ public class CrewController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long crewId) {
         
-        Long applicantId = userDetails.getMemberId();
-        crewService.applyToJoinCrew(crewId, applicantId);
+        Long memberId = userDetails.getMemberId();
+        crewService.applyToJoinCrew(crewId, memberId);
         
         return ApiResponse.ok();
     }
@@ -44,8 +45,20 @@ public class CrewController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long crewId) {
         
-        Long applicantId = userDetails.getMemberId();
-        crewService.cancelCrewApplication(crewId, applicantId);
+        Long memberId = userDetails.getMemberId();
+        crewService.cancelCrewApplication(crewId, memberId);
+        
+        return ApiResponse.ok();
+    }
+    
+    @PostMapping("/approval/{crewId}")
+    public ApiResponse<Void> processJoinRequest(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @RequestBody CrewApprovalDTO.Request request) {
+        
+        Long leaderId = userDetails.getMemberId();
+        crewService.processJoinRequest(crewId, request, leaderId);
         
         return ApiResponse.ok();
     }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -111,4 +111,15 @@ public class CrewController {
         
         return ApiResponse.ok();
     }
+    
+    @PostMapping("/leave/{crewId}")
+    public ApiResponse<Void> leaveCrew(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        Long memberId = userDetails.getMemberId();
+        crewService.leaveCrew(crewId, memberId);
+        
+        return ApiResponse.ok();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -1,0 +1,30 @@
+package com.runtracker.domain.crew.controller;
+
+import com.runtracker.domain.crew.dto.CrewCreateDTO;
+import com.runtracker.domain.crew.service.CrewService;
+import com.runtracker.global.response.ApiResponse;
+import com.runtracker.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/crew")
+public class CrewController {
+
+    private final CrewService crewService;
+
+    @PostMapping("/create")
+    public ApiResponse<Void> createCrew(
+            @RequestBody CrewCreateDTO.Request request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        
+        Long leaderId = userDetails.getMemberId();
+        crewService.createCrew(request, leaderId);
+        
+        return ApiResponse.ok();
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -99,4 +99,16 @@ public class CrewController {
         
         return ApiResponse.ok();
     }
+    
+    @PostMapping("/ban/{crewId}")
+    public ApiResponse<Void> banCrewMember(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @RequestParam Long memberId) {
+        
+        Long managerId = userDetails.getMemberId();
+        crewService.banCrewMember(crewId, memberId, managerId);
+        
+        return ApiResponse.ok();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewApprovalDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewApprovalDTO.java
@@ -1,0 +1,15 @@
+package com.runtracker.domain.crew.dto;
+
+import lombok.*;
+
+public class CrewApprovalDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private Long memberId;     // 신청한 회원 ID
+        private Boolean approved;  // 승인 유무 (true: 승인, false: 거절)
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewCreateDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewCreateDTO.java
@@ -1,0 +1,32 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.course.enums.Difficulty;
+import com.runtracker.domain.crew.entity.Crew;
+import lombok.*;
+
+public class CrewCreateDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private String title;
+        private String photo;
+        private String introduce;
+        private String region;
+        private Difficulty difficulty;
+        
+        public Crew toEntity(Long leaderId) {
+            return Crew.builder()
+                    .title(this.title)
+                    .photo(this.photo)
+                    .introduce(this.introduce)
+                    .region(this.region)
+                    .difficulty(this.difficulty)
+                    .leaderId(leaderId)
+                    .build();
+        }
+    }
+
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewDetailDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewDetailDTO.java
@@ -1,0 +1,78 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.course.enums.Difficulty;
+import com.runtracker.domain.crew.entity.Crew;
+import com.runtracker.domain.crew.entity.CrewMember;
+import com.runtracker.domain.crew.enums.CrewMemberStatus;
+import com.runtracker.domain.member.entity.enums.MemberRole;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CrewDetailDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberInfo {
+        private Long memberId;
+        private MemberRole role;
+        private CrewMemberStatus status;
+        private LocalDateTime joinedAt;
+
+        public static MemberInfo from(CrewMember crewMember) {
+            return MemberInfo.builder()
+                    .memberId(crewMember.getMemberId())
+                    .role(crewMember.getRole())
+                    .status(crewMember.getStatus())
+                    .joinedAt(crewMember.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private Long id;
+        private String title;
+        private String photo;
+        private String introduce;
+        private String region;
+        private Difficulty difficulty;
+        private String schedules;
+        private Long leaderId;
+        private Integer totalMemberCount;
+        private Integer activeMemberCount;
+        private List<MemberInfo> members;
+        private LocalDateTime createdAt;
+
+        public static Response from(Crew crew, List<CrewMember> allMembers) {
+            List<CrewMember> activeMembers = allMembers.stream()
+                    .filter(member -> member.getStatus() == CrewMemberStatus.ACTIVE)
+                    .toList();
+
+            List<MemberInfo> memberInfos = activeMembers.stream()
+                    .map(MemberInfo::from)
+                    .toList();
+
+            return Response.builder()
+                    .id(crew.getId())
+                    .title(crew.getTitle())
+                    .photo(crew.getPhoto())
+                    .introduce(crew.getIntroduce())
+                    .region(crew.getRegion())
+                    .difficulty(crew.getDifficulty())
+                    .schedules(crew.getSchedules())
+                    .leaderId(crew.getLeaderId())
+                    .totalMemberCount(allMembers.size())
+                    .activeMemberCount(activeMembers.size())
+                    .members(memberInfos)
+                    .createdAt(crew.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewListDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewListDTO.java
@@ -1,0 +1,57 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.course.enums.Difficulty;
+import com.runtracker.domain.crew.entity.Crew;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CrewListDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private Long id;
+        private String title;
+        private String photo;
+        private String introduce;
+        private String region;
+        private Difficulty difficulty;
+        private Long leaderId;
+        private Integer memberCount;
+        private LocalDateTime createdAt;
+
+        public static Response from(Crew crew, Integer memberCount) {
+            return Response.builder()
+                    .id(crew.getId())
+                    .title(crew.getTitle())
+                    .photo(crew.getPhoto())
+                    .introduce(crew.getIntroduce())
+                    .region(crew.getRegion())
+                    .difficulty(crew.getDifficulty())
+                    .leaderId(crew.getLeaderId())
+                    .memberCount(memberCount)
+                    .createdAt(crew.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ListResponse {
+        private List<Response> crews;
+        private Integer totalCount;
+
+        public static ListResponse of(List<Response> crews) {
+            return ListResponse.builder()
+                    .crews(crews)
+                    .totalCount(crews.size())
+                    .build();
+        }
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewManagementDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewManagementDTO.java
@@ -1,0 +1,70 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.crew.entity.CrewMember;
+import com.runtracker.domain.crew.enums.CrewMemberStatus;
+import com.runtracker.domain.member.entity.enums.MemberRole;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CrewManagementDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberInfo {
+        private Long memberId;
+        private String name;
+        private Integer age;
+        private Boolean gender;
+        private MemberRole role;
+        private CrewMemberStatus status;
+        private LocalDateTime requestedAt;
+
+        public static MemberInfo from(CrewMember crewMember, String name, Integer age, Boolean gender) {
+            return MemberInfo.builder()
+                    .memberId(crewMember.getMemberId())
+                    .name(name)
+                    .age(age)
+                    .gender(gender)
+                    .role(crewMember.getRole())
+                    .status(crewMember.getStatus())
+                    .requestedAt(crewMember.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PendingMembersResponse {
+        private List<MemberInfo> pendingMembers;
+        private Integer totalCount;
+
+        public static PendingMembersResponse of(List<MemberInfo> pendingMembers) {
+            return PendingMembersResponse.builder()
+                    .pendingMembers(pendingMembers)
+                    .totalCount(pendingMembers.size())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BannedMembersResponse {
+        private List<MemberInfo> bannedMembers;
+        private Integer totalCount;
+
+        public static BannedMembersResponse of(List<MemberInfo> bannedMembers) {
+            return BannedMembersResponse.builder()
+                    .bannedMembers(bannedMembers)
+                    .totalCount(bannedMembers.size())
+                    .build();
+        }
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewMemberUpdateDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewMemberUpdateDTO.java
@@ -1,0 +1,19 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.member.entity.enums.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CrewMemberUpdateDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private Long memberId;
+        private MemberRole role;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewUpdateDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewUpdateDTO.java
@@ -1,0 +1,22 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.course.enums.Difficulty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CrewUpdateDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private String title;
+        private String photo;
+        private String introduce;
+        private String region;
+        private Difficulty difficulty;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/MemberProfileDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/MemberProfileDTO.java
@@ -1,0 +1,36 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.member.entity.Member;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberProfileDTO {
+    private Long memberId;
+    private String socialId;
+    private String photo;
+    private String name;
+    private String introduce;
+    private Integer age;
+    private Boolean gender;
+    private String region;
+    private String difficulty;
+    private Double temperature;
+
+    public static MemberProfileDTO from(Member member) {
+        return MemberProfileDTO.builder()
+                .memberId(member.getId())
+                .socialId(member.getSocialId())
+                .photo(member.getPhoto())
+                .name(member.getName())
+                .introduce(member.getIntroduce())
+                .age(member.getAge())
+                .gender(member.getGender())
+                .region(member.getRegion())
+                .difficulty(member.getDifficulty())
+                .temperature(member.getTemperature())
+                .build();
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/Crew.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/Crew.java
@@ -33,9 +33,6 @@ public class Crew extends BaseEntity {
     @Column(name = "difficulty", length = 20)
     private Difficulty difficulty;
 
-    @Column(name = "crews", columnDefinition = "JSON")
-    private String crews;
-
     @Column(name = "schedules", columnDefinition = "JSON")
     private String schedules;
 

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/Crew.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/Crew.java
@@ -1,0 +1,64 @@
+package com.runtracker.domain.crew.entity;
+
+import com.runtracker.domain.course.enums.Difficulty;
+import com.runtracker.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "crew")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Crew extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", length = 100, nullable = false)
+    private String title;
+
+    @Column(name = "photo", length = 255)
+    private String photo;
+
+    @Column(name = "introduce", columnDefinition = "TEXT")
+    private String introduce;
+
+    @Column(name = "region", length = 100)
+    private String region;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", length = 20)
+    private Difficulty difficulty;
+
+    @Column(name = "crews", columnDefinition = "JSON")
+    private String crews;
+
+    @Column(name = "schedules", columnDefinition = "JSON")
+    private String schedules;
+
+    @Column(name = "leader_id", nullable = false)
+    private Long leaderId;
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updatePhoto(String photo) {
+        this.photo = photo;
+    }
+
+    public void updateIntroduce(String introduce) {
+        this.introduce = introduce;
+    }
+
+    public void updateRegion(String region) {
+        this.region = region;
+    }
+
+    public void updateDifficulty(Difficulty difficulty) {
+        this.difficulty = difficulty;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
@@ -35,4 +35,8 @@ public class CrewMember extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", columnDefinition = "VARCHAR(20) DEFAULT 'ACTIVE'")
     private CrewMemberStatus status = CrewMemberStatus.ACTIVE;
+    
+    public void approve() {
+        this.status = CrewMemberStatus.ACTIVE;
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
@@ -1,0 +1,38 @@
+package com.runtracker.domain.crew.entity;
+
+import com.runtracker.domain.crew.enums.CrewMemberStatus;
+import com.runtracker.domain.member.entity.enums.MemberRole;
+import com.runtracker.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "crew_member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CrewMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "crew_id", nullable = false)
+    private Long crewId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private MemberRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", columnDefinition = "VARCHAR(20) DEFAULT 'ACTIVE'")
+    private CrewMemberStatus status = CrewMemberStatus.ACTIVE;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
@@ -34,6 +34,7 @@ public class CrewMember extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", columnDefinition = "VARCHAR(20) DEFAULT 'ACTIVE'")
+    @Builder.Default
     private CrewMemberStatus status = CrewMemberStatus.ACTIVE;
     
     public void approve() {
@@ -43,5 +44,9 @@ public class CrewMember extends BaseEntity {
     
     public void updateRole(MemberRole role) {
         this.role = role;
+    }
+    
+    public void ban() {
+        this.status = CrewMemberStatus.BANNED;
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
@@ -29,7 +29,7 @@ public class CrewMember extends BaseEntity {
     private Long memberId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
+    @Column(name = "role", nullable = false, length = 20)
     private MemberRole role;
 
     @Enumerated(EnumType.STRING)
@@ -38,5 +38,9 @@ public class CrewMember extends BaseEntity {
     
     public void approve() {
         this.status = CrewMemberStatus.ACTIVE;
+    }
+    
+    public void updateRole(MemberRole role) {
+        this.role = role;
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMember.java
@@ -38,6 +38,7 @@ public class CrewMember extends BaseEntity {
     
     public void approve() {
         this.status = CrewMemberStatus.ACTIVE;
+        this.role = MemberRole.CREW_MEMBER;
     }
     
     public void updateRole(MemberRole role) {

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -13,7 +13,8 @@ public enum CrewErrorCode implements ResponseCode {
     CREW_NOT_FOUND("CR003", "크루를 찾을 수 없습니다."),
     CREW_MEMBER_NOT_FOUND("CR004", "크루 멤버를 찾을 수 없습니다."),
     ALREADY_CREW_MEMBER("CR005", "이미 크루에 가입된 멤버입니다."),
-    CREW_APPLICATION_PENDING("CR006", "이미 크루 가입 신청이 진행 중입니다.");
+    CREW_APPLICATION_PENDING("CR006", "이미 크루 가입 신청이 진행 중입니다."),
+    NO_PENDING_APPLICATION("CR007", "취소할 가입 신청이 없습니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -1,0 +1,18 @@
+package com.runtracker.domain.crew.enums;
+
+import com.runtracker.global.code.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CrewErrorCode implements ResponseCode {
+
+    MEMBER_NOT_FOUND("CR001", "멤버를 찾을 수 없습니다."),
+    CREW_ALREADY_EXISTS("CR002", "이미 생성한 크루가 존재합니다."),
+    CREW_NOT_FOUND("CR003", "크루를 찾을 수 없습니다."),
+    CREW_MEMBER_NOT_FOUND("CR004", "크루 멤버를 찾을 수 없습니다.");
+
+    private final String statusCode;
+    private final String message;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -11,7 +11,9 @@ public enum CrewErrorCode implements ResponseCode {
     MEMBER_NOT_FOUND("CR001", "멤버를 찾을 수 없습니다."),
     CREW_ALREADY_EXISTS("CR002", "이미 생성한 크루가 존재합니다."),
     CREW_NOT_FOUND("CR003", "크루를 찾을 수 없습니다."),
-    CREW_MEMBER_NOT_FOUND("CR004", "크루 멤버를 찾을 수 없습니다.");
+    CREW_MEMBER_NOT_FOUND("CR004", "크루 멤버를 찾을 수 없습니다."),
+    ALREADY_CREW_MEMBER("CR005", "이미 크루에 가입된 멤버입니다."),
+    CREW_APPLICATION_PENDING("CR006", "이미 크루 가입 신청이 진행 중입니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -16,7 +16,10 @@ public enum CrewErrorCode implements ResponseCode {
     CREW_APPLICATION_PENDING("CR006", "이미 크루 가입 신청이 진행 중입니다."),
     NO_PENDING_APPLICATION("CR007", "취소할 가입 신청이 없습니다."),
     NOT_CREW_LEADER("CR008", "크루 관리 권한이 없습니다."),
-    APPLICANT_NOT_FOUND("CR009", "해당 가입 신청자를 찾을 수 없습니다.");
+    APPLICANT_NOT_FOUND("CR009", "해당 가입 신청자를 찾을 수 없습니다."),
+    CANNOT_MODIFY_LEADER_ROLE("CR010", "크루장의 권한은 변경할 수 없습니다."),
+    SAME_ROLE_UPDATE("CR011", "이미 동일한 권한을 가지고 있습니다."),
+    INVALID_CREW_ROLE("CR012", "크루에서 사용할 수 없는 권한입니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -19,7 +19,8 @@ public enum CrewErrorCode implements ResponseCode {
     APPLICANT_NOT_FOUND("CR009", "해당 가입 신청자를 찾을 수 없습니다."),
     CANNOT_MODIFY_LEADER_ROLE("CR010", "크루장의 권한은 변경할 수 없습니다."),
     SAME_ROLE_UPDATE("CR011", "이미 동일한 권한을 가지고 있습니다."),
-    INVALID_CREW_ROLE("CR012", "크루에서 사용할 수 없는 권한입니다.");
+    INVALID_CREW_ROLE("CR012", "크루에서 사용할 수 없는 권한입니다."),
+    ALREADY_JOINED_OTHER_CREW("CR013", "이미 다른 크루에 가입되어 있습니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -20,7 +20,11 @@ public enum CrewErrorCode implements ResponseCode {
     CANNOT_MODIFY_LEADER_ROLE("CR010", "크루장의 권한은 변경할 수 없습니다."),
     SAME_ROLE_UPDATE("CR011", "이미 동일한 권한을 가지고 있습니다."),
     INVALID_CREW_ROLE("CR012", "크루에서 사용할 수 없는 권한입니다."),
-    ALREADY_JOINED_OTHER_CREW("CR013", "이미 다른 크루에 가입되어 있습니다.");
+    ALREADY_JOINED_OTHER_CREW("CR013", "이미 다른 크루에 가입되어 있습니다."),
+    CANNOT_KICK_CREW_LEADER("CR014", "크루장은 추방할 수 없습니다."),
+    CANNOT_KICK_YOURSELF("CR015", "자기 자신을 추방할 수 없습니다."),
+    CANNOT_KICK_MANAGER_AS_MANAGER("CR016", "매니저는 다른 매니저를 추방할 수 없습니다."),
+    BANNED_FROM_CREW("CR017", "해당 크루에서 차단된 회원입니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -24,7 +24,8 @@ public enum CrewErrorCode implements ResponseCode {
     CANNOT_KICK_CREW_LEADER("CR014", "크루장은 추방할 수 없습니다."),
     CANNOT_KICK_YOURSELF("CR015", "자기 자신을 추방할 수 없습니다."),
     CANNOT_KICK_MANAGER_AS_MANAGER("CR016", "매니저는 다른 매니저를 추방할 수 없습니다."),
-    BANNED_FROM_CREW("CR017", "해당 크루에서 차단된 회원입니다.");
+    BANNED_FROM_CREW("CR017", "해당 크루에서 차단된 회원입니다."),
+    CANNOT_LEAVE_AS_CREW_LEADER("CR018", "크루장은 크루를 나갈 수 없습니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -14,7 +14,9 @@ public enum CrewErrorCode implements ResponseCode {
     CREW_MEMBER_NOT_FOUND("CR004", "크루 멤버를 찾을 수 없습니다."),
     ALREADY_CREW_MEMBER("CR005", "이미 크루에 가입된 멤버입니다."),
     CREW_APPLICATION_PENDING("CR006", "이미 크루 가입 신청이 진행 중입니다."),
-    NO_PENDING_APPLICATION("CR007", "취소할 가입 신청이 없습니다.");
+    NO_PENDING_APPLICATION("CR007", "취소할 가입 신청이 없습니다."),
+    NOT_CREW_LEADER("CR008", "크루 관리 권한이 없습니다."),
+    APPLICANT_NOT_FOUND("CR009", "해당 가입 신청자를 찾을 수 없습니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewMemberStatus.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewMemberStatus.java
@@ -1,0 +1,18 @@
+package com.runtracker.domain.crew.enums;
+
+public enum CrewMemberStatus {
+    ACTIVE("활성화"),
+    PENDING("승인 대기"),
+    BANNED("차단"),
+    WITHDRAWN("탈퇴");
+
+    private final String description;
+
+    CrewMemberStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyCrewMemberException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyCrewMemberException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class AlreadyCrewMemberException extends CustomException {
+    public AlreadyCrewMemberException() {
+        super(CrewErrorCode.ALREADY_CREW_MEMBER);
+    }
+
+    public AlreadyCrewMemberException(String message) {
+        super(CrewErrorCode.ALREADY_CREW_MEMBER, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyJoinedOtherCrewException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyJoinedOtherCrewException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class AlreadyJoinedOtherCrewException extends CustomException {
+    public AlreadyJoinedOtherCrewException() {
+        super(CrewErrorCode.ALREADY_JOINED_OTHER_CREW);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/ApplicantNotFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/ApplicantNotFoundException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class ApplicantNotFoundException extends CustomException {
+    public ApplicantNotFoundException() {
+        super(CrewErrorCode.APPLICANT_NOT_FOUND);
+    }
+
+    public ApplicantNotFoundException(String message) {
+        super(CrewErrorCode.APPLICANT_NOT_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/BannedFromCrewException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/BannedFromCrewException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class BannedFromCrewException extends CustomException {
+    public BannedFromCrewException() {
+        super(CrewErrorCode.BANNED_FROM_CREW);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotKickCrewLeaderException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotKickCrewLeaderException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotKickCrewLeaderException extends CustomException {
+    public CannotKickCrewLeaderException() {
+        super(CrewErrorCode.CANNOT_KICK_CREW_LEADER);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotKickManagerAsManagerException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotKickManagerAsManagerException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotKickManagerAsManagerException extends CustomException {
+    public CannotKickManagerAsManagerException() {
+        super(CrewErrorCode.CANNOT_KICK_MANAGER_AS_MANAGER);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotKickYourselfException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotKickYourselfException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotKickYourselfException extends CustomException {
+    public CannotKickYourselfException() {
+        super(CrewErrorCode.CANNOT_KICK_YOURSELF);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotLeaveAsCrewLeaderException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotLeaveAsCrewLeaderException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotLeaveAsCrewLeaderException extends CustomException {
+    public CannotLeaveAsCrewLeaderException() {
+        super(CrewErrorCode.CANNOT_LEAVE_AS_CREW_LEADER);
+    }
+
+    public CannotLeaveAsCrewLeaderException(String message) {
+        super(CrewErrorCode.CANNOT_LEAVE_AS_CREW_LEADER, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotModifyLeaderRoleException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotModifyLeaderRoleException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotModifyLeaderRoleException extends CustomException {
+    public CannotModifyLeaderRoleException() {
+        super(CrewErrorCode.CANNOT_MODIFY_LEADER_ROLE);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewAlreadyExistsException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewAlreadyExistsException extends CustomException {
+    public CrewAlreadyExistsException() {
+        super(CrewErrorCode.CREW_ALREADY_EXISTS);
+    }
+
+    public CrewAlreadyExistsException(String message) {
+        super(CrewErrorCode.CREW_ALREADY_EXISTS, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewApplicationPendingException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewApplicationPendingException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewApplicationPendingException extends CustomException {
+    public CrewApplicationPendingException() {
+        super(CrewErrorCode.CREW_APPLICATION_PENDING);
+    }
+
+    public CrewApplicationPendingException(String message) {
+        super(CrewErrorCode.CREW_APPLICATION_PENDING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewMemberNotFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewMemberNotFoundException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewMemberNotFoundException extends CustomException {
+    public CrewMemberNotFoundException() {
+        super(CrewErrorCode.CREW_MEMBER_NOT_FOUND);
+    }
+
+    public CrewMemberNotFoundException(String message) {
+        super(CrewErrorCode.CREW_MEMBER_NOT_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewNotFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewNotFoundException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewNotFoundException extends CustomException {
+    public CrewNotFoundException() {
+        super(CrewErrorCode.CREW_NOT_FOUND);
+    }
+
+    public CrewNotFoundException(String message) {
+        super(CrewErrorCode.CREW_NOT_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/InvalidCrewRoleException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/InvalidCrewRoleException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class InvalidCrewRoleException extends CustomException {
+    public InvalidCrewRoleException() {
+        super(CrewErrorCode.INVALID_CREW_ROLE);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/MemberNotFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/MemberNotFoundException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class MemberNotFoundException extends CustomException {
+    public MemberNotFoundException() {
+        super(CrewErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    public MemberNotFoundException(String message) {
+        super(CrewErrorCode.MEMBER_NOT_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/NoPendingApplicationException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/NoPendingApplicationException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class NoPendingApplicationException extends CustomException {
+    public NoPendingApplicationException() {
+        super(CrewErrorCode.NO_PENDING_APPLICATION);
+    }
+
+    public NoPendingApplicationException(String message) {
+        super(CrewErrorCode.NO_PENDING_APPLICATION, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/NotCrewLeaderException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/NotCrewLeaderException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class NotCrewLeaderException extends CustomException {
+    public NotCrewLeaderException() {
+        super(CrewErrorCode.NOT_CREW_LEADER);
+    }
+
+    public NotCrewLeaderException(String message) {
+        super(CrewErrorCode.NOT_CREW_LEADER, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/SameRoleUpdateException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/SameRoleUpdateException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class SameRoleUpdateException extends CustomException {
+    public SameRoleUpdateException() {
+        super(CrewErrorCode.SAME_ROLE_UPDATE);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRepository.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.repository;
+
+import com.runtracker.domain.crew.entity.CrewMember;
+import com.runtracker.domain.member.entity.enums.MemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CrewMemberRepository extends JpaRepository<CrewMember, Long> {
+
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRepository.java
@@ -1,6 +1,7 @@
 package com.runtracker.domain.crew.repository;
 
 import com.runtracker.domain.crew.entity.CrewMember;
+import com.runtracker.domain.crew.enums.CrewMemberStatus;
 import com.runtracker.domain.member.entity.enums.MemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,6 @@ import java.util.Optional;
 @Repository
 public interface CrewMemberRepository extends JpaRepository<CrewMember, Long> {
     Optional<CrewMember> findByCrewIdAndMemberId(Long crewId, Long memberId);
+    List<CrewMember> findByCrewId(Long crewId);
+    List<CrewMember> findByMemberIdAndStatus(Long memberId, CrewMemberStatus status);
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 @Repository
 public interface CrewMemberRepository extends JpaRepository<CrewMember, Long> {
-
+    Optional<CrewMember> findByCrewIdAndMemberId(Long crewId, Long memberId);
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRepository.java
@@ -1,0 +1,13 @@
+package com.runtracker.domain.crew.repository;
+
+import com.runtracker.domain.crew.entity.Crew;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CrewRepository extends JpaRepository<Crew, Long> {
+    
+    List<Crew> findByLeaderId(Long leaderId);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
@@ -1,0 +1,48 @@
+package com.runtracker.domain.crew.service;
+
+import com.runtracker.domain.crew.dto.CrewCreateDTO;
+import com.runtracker.domain.crew.entity.Crew;
+import com.runtracker.domain.crew.entity.CrewMember;
+import com.runtracker.domain.crew.enums.CrewMemberStatus;
+import com.runtracker.domain.crew.exception.CrewAlreadyExistsException;
+import com.runtracker.domain.crew.exception.MemberNotFoundException;
+import com.runtracker.domain.crew.repository.CrewRepository;
+import com.runtracker.domain.crew.repository.CrewMemberRepository;
+import com.runtracker.domain.member.entity.enums.MemberRole;
+import com.runtracker.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CrewService {
+
+    private final CrewRepository crewRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final MemberRepository memberRepository;
+
+    public void createCrew(CrewCreateDTO.Request request, Long leaderId) {
+        memberRepository.findById(leaderId)
+                .orElseThrow(MemberNotFoundException::new);
+        
+        List<Crew> existingCrews = crewRepository.findByLeaderId(leaderId);
+        if (!existingCrews.isEmpty()) {
+            throw new CrewAlreadyExistsException();
+        }
+        
+        Crew crew = request.toEntity(leaderId);
+        crewRepository.save(crew);
+        
+        CrewMember crewLeader = CrewMember.builder()
+                .crewId(crew.getId())
+                .memberId(leaderId)
+                .role(MemberRole.CREW_LEADER)
+                .status(CrewMemberStatus.ACTIVE)
+                .build();
+        crewMemberRepository.save(crewLeader);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
@@ -3,6 +3,7 @@ package com.runtracker.domain.crew.service;
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
 import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
+import com.runtracker.domain.crew.dto.CrewUpdateDTO;
 import com.runtracker.domain.crew.entity.Crew;
 import com.runtracker.domain.crew.entity.CrewMember;
 import com.runtracker.domain.crew.enums.CrewMemberStatus;
@@ -150,8 +151,43 @@ public class CrewService {
         crewMemberRepository.save(targetMember);
     }
     
+    public void updateCrew(Long crewId, CrewUpdateDTO.Request request, Long leaderId) {
+        validateCrewLeaderPermission(crewId, leaderId);
+        
+        Crew crew = crewRepository.findById(crewId)
+                .orElseThrow(CrewNotFoundException::new);
+        
+        if (request.getTitle() != null) {
+            crew.updateTitle(request.getTitle());
+        }
+        if (request.getPhoto() != null) {
+            crew.updatePhoto(request.getPhoto());
+        }
+        if (request.getIntroduce() != null) {
+            crew.updateIntroduce(request.getIntroduce());
+        }
+        if (request.getRegion() != null) {
+            crew.updateRegion(request.getRegion());
+        }
+        if (request.getDifficulty() != null) {
+            crew.updateDifficulty(request.getDifficulty());
+        }
+        
+        crewRepository.save(crew);
+    }
+    
     private boolean isValidCrewRole(MemberRole role) {
         return role == MemberRole.CREW_MEMBER || role == MemberRole.CREW_MANAGER;
+    }
+    
+    private void validateCrewLeaderPermission(Long crewId, Long memberId) {
+        CrewMember member = crewMemberRepository
+                .findByCrewIdAndMemberId(crewId, memberId)
+                .orElseThrow(NotCrewLeaderException::new);
+
+        if (member.getRole() != MemberRole.CREW_LEADER) {
+            throw new NotCrewLeaderException();
+        }
     }
     
     private void validateCrewManagementPermission(Long crewId, Long memberId) {

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
@@ -9,6 +9,7 @@ import com.runtracker.domain.crew.exception.CrewAlreadyExistsException;
 import com.runtracker.domain.crew.exception.CrewApplicationPendingException;
 import com.runtracker.domain.crew.exception.CrewNotFoundException;
 import com.runtracker.domain.crew.exception.MemberNotFoundException;
+import com.runtracker.domain.crew.exception.NoPendingApplicationException;
 import com.runtracker.domain.crew.repository.CrewRepository;
 import com.runtracker.domain.crew.repository.CrewMemberRepository;
 import com.runtracker.domain.member.entity.enums.MemberRole;
@@ -76,5 +77,23 @@ public class CrewService {
                 .status(CrewMemberStatus.PENDING)
                 .build();
         crewMemberRepository.save(newApplication);
+    }
+    
+    public void cancelCrewApplication(Long crewId, Long applicantId) {
+        memberRepository.findById(applicantId)
+                .orElseThrow(MemberNotFoundException::new);
+        
+        crewRepository.findById(crewId)
+                .orElseThrow(CrewNotFoundException::new);
+        
+        CrewMember application = crewMemberRepository
+                .findByCrewIdAndMemberId(crewId, applicantId)
+                .orElseThrow(NoPendingApplicationException::new);
+        
+        if (application.getStatus() != CrewMemberStatus.PENDING) {
+            throw new NoPendingApplicationException();
+        }
+        
+        crewMemberRepository.delete(application);
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
@@ -14,6 +14,7 @@ import com.runtracker.domain.crew.exception.BannedFromCrewException;
 import com.runtracker.domain.crew.exception.CannotKickCrewLeaderException;
 import com.runtracker.domain.crew.exception.CannotKickManagerAsManagerException;
 import com.runtracker.domain.crew.exception.CannotKickYourselfException;
+import com.runtracker.domain.crew.exception.CannotLeaveAsCrewLeaderException;
 import com.runtracker.domain.crew.exception.CannotModifyLeaderRoleException;
 import com.runtracker.domain.crew.exception.CrewAlreadyExistsException;
 import com.runtracker.domain.crew.exception.CrewApplicationPendingException;
@@ -251,6 +252,28 @@ public class CrewService {
 
         targetMember.ban();
         crewMemberRepository.save(targetMember);
+    }
+    
+    public void leaveCrew(Long crewId, Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        
+        crewRepository.findById(crewId)
+                .orElseThrow(CrewNotFoundException::new);
+        
+        CrewMember crewMember = crewMemberRepository
+                .findByCrewIdAndMemberId(crewId, memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        
+        if (crewMember.getStatus() != CrewMemberStatus.ACTIVE) {
+            throw new MemberNotFoundException();
+        }
+        
+        if (crewMember.getRole() == MemberRole.CREW_LEADER) {
+            throw new CannotLeaveAsCrewLeaderException();
+        }
+        
+        crewMemberRepository.delete(crewMember);
     }
     
     private boolean isValidCrewRole(MemberRole role) {

--- a/runtracker/src/main/java/com/runtracker/domain/member/entity/enums/MemberRole.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/entity/enums/MemberRole.java
@@ -3,6 +3,7 @@ package com.runtracker.domain.member.entity.enums;
 public enum MemberRole {
     USER("일반 사용자"),
     CREW_LEADER("크루장"),
+    CREW_MANAGER("크루 매니저"),
     CREW_MEMBER("크루원"),
     ADMIN("관리자");
     

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -100,6 +101,41 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                                 ResourceSnippetParameters.builder()
                                         .tag("crew")
                                         .description("크루 가입 신청")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+    
+    @Test
+    void cancelCrewApplication() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(789L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_789");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(789L)
+                .socialId("kakao_789")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("789")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(post("/api/crew/join/cancel/{crewId}", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-cancel-application",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 가입 신청 취소")
                                         .requestHeaders(
                                                 headerWithName("Authorization").description("액세스 토큰")
                                         )

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -362,4 +362,42 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                                         .build()
                         )));
     }
+    
+    @Test
+    void leaveCrew() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(444L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_444");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(444L)
+                .socialId("kakao_444")
+                .roles(List.of(MemberRole.CREW_MEMBER))
+                .build();
+        given(userDetailsService.loadUserByUsername("444")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(post("/api/crew/leave/{crewId}", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-leave",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 나가기")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("crewId").description("나갈 크루 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
 }

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.util.List;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -323,5 +324,42 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                                         .build()
                         )
                 ));
+    }
+    
+    @Test
+    void banCrewMember() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(555L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_555");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(555L)
+                .socialId("kakao_555")
+                .roles(List.of(MemberRole.CREW_LEADER))
+                .build();
+        given(userDetailsService.loadUserByUsername("555")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(post("/api/crew/ban/{crewId}?memberId=123", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-ban-member",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루원 차단")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .queryParameters(
+                                                parameterWithName("memberId").description("차단할 회원 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )));
     }
 }

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -5,8 +5,13 @@ import com.runtracker.RunTrackerDocumentApiTester;
 import com.runtracker.domain.course.enums.Difficulty;
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
+import com.runtracker.domain.crew.dto.CrewDetailDTO;
+import com.runtracker.domain.crew.dto.CrewListDTO;
+import com.runtracker.domain.crew.dto.CrewManagementDTO;
 import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
 import com.runtracker.domain.crew.dto.CrewUpdateDTO;
+import com.runtracker.domain.crew.dto.MemberProfileDTO;
+import com.runtracker.domain.crew.enums.CrewMemberStatus;
 import com.runtracker.domain.crew.service.CrewService;
 import com.runtracker.domain.member.entity.enums.MemberRole;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -14,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
@@ -23,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -395,6 +402,377 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
                                                 fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
                                                 fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+    
+    @Test
+    void getCrewList() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(200L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_200");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(200L)
+                .socialId("kakao_200")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("200")).willReturn(mockUserDetails);
+        
+        List<CrewListDTO.Response> mockCrews = List.of(
+                CrewListDTO.Response.builder()
+                        .id(1L)
+                        .title("러닝크루 초급자")
+                        .photo("https://example.com/crew1.jpg")
+                        .introduce("초급자를 위한 러닝크루입니다.")
+                        .region("서울시 강남구")
+                        .difficulty(Difficulty.EASY)
+                        .leaderId(123L)
+                        .memberCount(5)
+                        .createdAt(LocalDateTime.of(2024, 1, 1, 10, 0))
+                        .build(),
+                CrewListDTO.Response.builder()
+                        .id(2L)
+                        .title("런닝 매니아")
+                        .photo("https://example.com/crew2.jpg")
+                        .introduce("고급 러너를 위한 크루입니다.")
+                        .region("서울시 서초구")
+                        .difficulty(Difficulty.HARD)
+                        .leaderId(456L)
+                        .memberCount(10)
+                        .createdAt(LocalDateTime.of(2024, 1, 15, 14, 30))
+                        .build()
+        );
+        
+        CrewListDTO.ListResponse mockResponse = CrewListDTO.ListResponse.of(mockCrews);
+        given(crewService.getAllCrews()).willReturn(mockResponse);
+        
+        // when
+        this.mockMvc.perform(get("/api/crew/list")
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-list",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 리스트 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body.crews").type(JsonFieldType.ARRAY).description("크루 목록"),
+                                                fieldWithPath("body.crews[].id").type(JsonFieldType.NUMBER).description("크루 ID"),
+                                                fieldWithPath("body.crews[].title").type(JsonFieldType.STRING).description("크루 이름"),
+                                                fieldWithPath("body.crews[].photo").type(JsonFieldType.STRING).description("크루 대표 사진 URL").optional(),
+                                                fieldWithPath("body.crews[].introduce").type(JsonFieldType.STRING).description("크루 소개").optional(),
+                                                fieldWithPath("body.crews[].region").type(JsonFieldType.STRING).description("크루 활동 지역").optional(),
+                                                fieldWithPath("body.crews[].difficulty").type(JsonFieldType.STRING).description("크루 난이도 (EASY, MEDIUM, HARD)").optional(),
+                                                fieldWithPath("body.crews[].leaderId").type(JsonFieldType.NUMBER).description("크루장 ID"),
+                                                fieldWithPath("body.crews[].memberCount").type(JsonFieldType.NUMBER).description("크루 멤버 수"),
+                                                fieldWithPath("body.crews[].createdAt").type(JsonFieldType.STRING).description("크루 생성일시"),
+                                                fieldWithPath("body.totalCount").type(JsonFieldType.NUMBER).description("전체 크루 개수")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+    
+    @Test
+    void getCrewDetail() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(300L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_300");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(300L)
+                .socialId("kakao_300")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("300")).willReturn(mockUserDetails);
+        
+        List<CrewDetailDTO.MemberInfo> mockMembers = List.of(
+                CrewDetailDTO.MemberInfo.builder()
+                        .memberId(123L)
+                        .role(MemberRole.CREW_LEADER)
+                        .status(CrewMemberStatus.ACTIVE)
+                        .joinedAt(LocalDateTime.of(2024, 1, 1, 10, 0))
+                        .build(),
+                CrewDetailDTO.MemberInfo.builder()
+                        .memberId(456L)
+                        .role(MemberRole.CREW_MANAGER)
+                        .status(CrewMemberStatus.ACTIVE)
+                        .joinedAt(LocalDateTime.of(2024, 1, 5, 14, 30))
+                        .build(),
+                CrewDetailDTO.MemberInfo.builder()
+                        .memberId(789L)
+                        .role(MemberRole.CREW_MEMBER)
+                        .status(CrewMemberStatus.ACTIVE)
+                        .joinedAt(LocalDateTime.of(2024, 1, 10, 16, 45))
+                        .build()
+        );
+        
+        CrewDetailDTO.Response mockResponse = CrewDetailDTO.Response.builder()
+                .id(1L)
+                .title("러닝크루 초급자")
+                .photo("https://example.com/crew-detail.jpg")
+                .introduce("초급자를 위한 러닝크루입니다. 함께 건강한 러닝 습관을 만들어 봐요!")
+                .region("서울시 강남구")
+                .difficulty(Difficulty.EASY)
+                .schedules("매주 화, 목 오후 7시")
+                .leaderId(123L)
+                .totalMemberCount(5)
+                .activeMemberCount(3)
+                .members(mockMembers)
+                .createdAt(LocalDateTime.of(2024, 1, 1, 10, 0))
+                .build();
+        
+        given(crewService.getCrewDetail(1L)).willReturn(mockResponse);
+        
+        // when
+        this.mockMvc.perform(get("/api/crew/{crewId}", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-detail",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 상세 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("crewId").description("조회할 크루 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body.id").type(JsonFieldType.NUMBER).description("크루 ID"),
+                                                fieldWithPath("body.title").type(JsonFieldType.STRING).description("크루 이름"),
+                                                fieldWithPath("body.photo").type(JsonFieldType.STRING).description("크루 대표 사진 URL").optional(),
+                                                fieldWithPath("body.introduce").type(JsonFieldType.STRING).description("크루 소개").optional(),
+                                                fieldWithPath("body.region").type(JsonFieldType.STRING).description("크루 활동 지역").optional(),
+                                                fieldWithPath("body.difficulty").type(JsonFieldType.STRING).description("크루 난이도 (EASY, MEDIUM, HARD)").optional(),
+                                                fieldWithPath("body.schedules").type(JsonFieldType.STRING).description("크루 활동 일정").optional(),
+                                                fieldWithPath("body.leaderId").type(JsonFieldType.NUMBER).description("크루장 ID"),
+                                                fieldWithPath("body.totalMemberCount").type(JsonFieldType.NUMBER).description("전체 멤버 수"),
+                                                fieldWithPath("body.activeMemberCount").type(JsonFieldType.NUMBER).description("활성 멤버 수"),
+                                                fieldWithPath("body.members").type(JsonFieldType.ARRAY).description("활성 멤버 목록"),
+                                                fieldWithPath("body.members[].memberId").type(JsonFieldType.NUMBER).description("멤버 ID"),
+                                                fieldWithPath("body.members[].role").type(JsonFieldType.STRING).description("멤버 권한 (CREW_LEADER, CREW_MANAGER, CREW_MEMBER)"),
+                                                fieldWithPath("body.members[].status").type(JsonFieldType.STRING).description("멤버 상태 (ACTIVE, PENDING, BANNED)"),
+                                                fieldWithPath("body.members[].joinedAt").type(JsonFieldType.STRING).description("가입일시"),
+                                                fieldWithPath("body.createdAt").type(JsonFieldType.STRING).description("크루 생성일시")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+    
+    @Test
+    void getPendingMembers() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(333L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_333");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(333L)
+                .socialId("kakao_333")
+                .roles(List.of(MemberRole.CREW_LEADER))
+                .build();
+        given(userDetailsService.loadUserByUsername("333")).willReturn(mockUserDetails);
+        
+        List<CrewManagementDTO.MemberInfo> mockPendingMembers = List.of(
+                CrewManagementDTO.MemberInfo.builder()
+                        .memberId(111L)
+                        .name("김러너")
+                        .age(25)
+                        .gender(true)
+                        .role(MemberRole.USER)
+                        .status(CrewMemberStatus.PENDING)
+                        .requestedAt(LocalDateTime.of(2024, 1, 20, 10, 0))
+                        .build(),
+                CrewManagementDTO.MemberInfo.builder()
+                        .memberId(222L)
+                        .name("이조거")
+                        .age(30)
+                        .gender(false)
+                        .role(MemberRole.USER)
+                        .status(CrewMemberStatus.PENDING)
+                        .requestedAt(LocalDateTime.of(2024, 1, 21, 14, 30))
+                        .build()
+        );
+        
+        CrewManagementDTO.PendingMembersResponse mockResponse = CrewManagementDTO.PendingMembersResponse.of(mockPendingMembers);
+        given(crewService.getPendingMembers(1L, 333L)).willReturn(mockResponse);
+
+        // when
+        this.mockMvc.perform(get("/api/crew/list/pending/{crewId}", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-pending-members",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 가입 요청자 목록 조회 (크루장/매니저 전용)")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("crewId").description("조회할 크루 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body.pendingMembers").type(JsonFieldType.ARRAY).description("가입 요청 대기 멤버 목록"),
+                                                fieldWithPath("body.pendingMembers[].memberId").type(JsonFieldType.NUMBER).description("요청자 멤버 ID"),
+                                                fieldWithPath("body.pendingMembers[].name").type(JsonFieldType.STRING).description("요청자 이름"),
+                                                fieldWithPath("body.pendingMembers[].age").type(JsonFieldType.NUMBER).description("요청자 나이"),
+                                                fieldWithPath("body.pendingMembers[].gender").type(JsonFieldType.BOOLEAN).description("요청자 성별 (true: 남성, false: 여성)"),
+                                                fieldWithPath("body.pendingMembers[].role").type(JsonFieldType.STRING).description("멤버 권한 (USER)"),
+                                                fieldWithPath("body.pendingMembers[].status").type(JsonFieldType.STRING).description("멤버 상태 (PENDING)"),
+                                                fieldWithPath("body.pendingMembers[].requestedAt").type(JsonFieldType.STRING).description("가입 신청일시"),
+                                                fieldWithPath("body.totalCount").type(JsonFieldType.NUMBER).description("총 가입 요청자 수")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+    
+    @Test
+    void getBannedMembers() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(333L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_333");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(333L)
+                .socialId("kakao_333")
+                .roles(List.of(MemberRole.CREW_LEADER))
+                .build();
+        given(userDetailsService.loadUserByUsername("333")).willReturn(mockUserDetails);
+        
+        List<CrewManagementDTO.MemberInfo> mockBannedMembers = List.of(
+                CrewManagementDTO.MemberInfo.builder()
+                        .memberId(999L)
+                        .name("박차단")
+                        .age(28)
+                        .gender(true)
+                        .role(MemberRole.CREW_MEMBER)
+                        .status(CrewMemberStatus.BANNED)
+                        .requestedAt(LocalDateTime.of(2024, 1, 10, 10, 0))
+                        .build(),
+                CrewManagementDTO.MemberInfo.builder()
+                        .memberId(888L)
+                        .name("최추방")
+                        .age(35)
+                        .gender(false)
+                        .role(MemberRole.CREW_MEMBER)
+                        .status(CrewMemberStatus.BANNED)
+                        .requestedAt(LocalDateTime.of(2024, 1, 15, 16, 30))
+                        .build()
+        );
+        
+        CrewManagementDTO.BannedMembersResponse mockResponse = CrewManagementDTO.BannedMembersResponse.of(mockBannedMembers);
+        given(crewService.getBannedMembers(1L, 333L)).willReturn(mockResponse);
+
+        // when
+        this.mockMvc.perform(get("/api/crew/list/banned/{crewId}", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-banned-members",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 차단된 멤버 목록 조회 (크루장/매니저 전용)")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("crewId").description("조회할 크루 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body.bannedMembers").type(JsonFieldType.ARRAY).description("차단된 멤버 목록"),
+                                                fieldWithPath("body.bannedMembers[].memberId").type(JsonFieldType.NUMBER).description("차단된 멤버 ID"),
+                                                fieldWithPath("body.bannedMembers[].name").type(JsonFieldType.STRING).description("차단된 멤버 이름"),
+                                                fieldWithPath("body.bannedMembers[].age").type(JsonFieldType.NUMBER).description("차단된 멤버 나이"),
+                                                fieldWithPath("body.bannedMembers[].gender").type(JsonFieldType.BOOLEAN).description("차단된 멤버 성별 (true: 남성, false: 여성)"),
+                                                fieldWithPath("body.bannedMembers[].role").type(JsonFieldType.STRING).description("멤버 권한 (CREW_MEMBER, CREW_MANAGER)"),
+                                                fieldWithPath("body.bannedMembers[].status").type(JsonFieldType.STRING).description("멤버 상태 (BANNED)"),
+                                                fieldWithPath("body.bannedMembers[].requestedAt").type(JsonFieldType.STRING).description("최초 가입일시"),
+                                                fieldWithPath("body.totalCount").type(JsonFieldType.NUMBER).description("총 차단된 멤버 수")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+    
+    @Test
+    void getMemberProfile() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(500L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_500");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(500L)
+                .socialId("kakao_500")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("500")).willReturn(mockUserDetails);
+        
+        MemberProfileDTO mockProfile = MemberProfileDTO.builder()
+                .memberId(123L)
+                .socialId("kakao_123")
+                .photo("https://example.com/profile123.jpg")
+                .name("김런닝")
+                .introduce("건강한 러닝을 좋아하는 김런닝입니다!")
+                .age(28)
+                .gender(true)
+                .region("서울시 강남구")
+                .difficulty("MEDIUM")
+                .temperature(36.5)
+                .build();
+        
+        given(crewService.getMemberProfile(123L, 500L)).willReturn(mockProfile);
+
+        // when
+        this.mockMvc.perform(get("/api/crew/member/{memberId}", 123L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("member-profile",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("유저 프로필 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("memberId").description("조회할 멤버 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body.memberId").type(JsonFieldType.NUMBER).description("멤버 ID"),
+                                                fieldWithPath("body.socialId").type(JsonFieldType.STRING).description("소셜 ID"),
+                                                fieldWithPath("body.photo").type(JsonFieldType.STRING).description("프로필 사진 URL").optional(),
+                                                fieldWithPath("body.name").type(JsonFieldType.STRING).description("이름"),
+                                                fieldWithPath("body.introduce").type(JsonFieldType.STRING).description("자기소개").optional(),
+                                                fieldWithPath("body.age").type(JsonFieldType.NUMBER).description("나이"),
+                                                fieldWithPath("body.gender").type(JsonFieldType.BOOLEAN).description("성별 (true: 남성, false: 여성)"),
+                                                fieldWithPath("body.region").type(JsonFieldType.STRING).description("지역").optional(),
+                                                fieldWithPath("body.difficulty").type(JsonFieldType.STRING).description("선호 난이도").optional(),
+                                                fieldWithPath("body.temperature").type(JsonFieldType.NUMBER).description("매너 온도").optional()
                                         )
                                         .build()
                         )

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -21,6 +21,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -278,6 +279,41 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("introduce").type(JsonFieldType.STRING).description("크루 소개").optional(),
                                                 fieldWithPath("region").type(JsonFieldType.STRING).description("크루 활동 지역").optional(),
                                                 fieldWithPath("difficulty").type(JsonFieldType.STRING).description("크루 난이도 (EASY, MEDIUM, HARD)").optional()
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+    
+    @Test
+    void deleteCrew() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(666L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_666");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(666L)
+                .socialId("kakao_666")
+                .roles(List.of(MemberRole.CREW_LEADER))
+                .build();
+        given(userDetailsService.loadUserByUsername("666")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(delete("/api/crew/delete/{crewId}", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-delete",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 삭제")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
                                         )
                                         .responseFields(
                                                 fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -77,4 +77,39 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                         )
                 ));
     }
+    
+    @Test
+    void applyToJoinCrew() throws Exception {
+        // given
+        given(jwtUtil.getMemberIdFromToken(any())).willReturn(456L);
+        given(jwtUtil.getSocialIdFromToken(any())).willReturn("kakao_456");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(456L)
+                .socialId("kakao_456")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("456")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(post("/api/crew/join/{crewId}", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-join",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew")
+                                        .description("크루 가입 신청")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
 }


### PR DESCRIPTION
## 구현된 전체 기능

### 크루 기본 관리
- **POST** `/api/crew/create` - 크루 생성
- **GET** `/api/crew/list` - 크루 리스트 조회
- **GET** `/api/crew/{crewId}` - 크루 상세 조회
- **PATCH** `/api/crew/update/{crewId}` - 크루 정보 수정 (크루장 전용)
- **DELETE** `/api/crew/delete/{crewId}` - 크루 삭제 (크루장 전용)

### 크루 가입 관리
- **POST** `/api/crew/join/{crewId}` - 크루 가입 신청
- **POST** `/api/crew/join/cancel/{crewId}` - 크루 가입 신청 취소
- **POST** `/api/crew/approval/{crewId}` - 크루 가입 승인/거절 (크루장/매니저 전용)
- **POST** `/api/crew/leave/{crewId}` - 크루 나가기 (크루장 제외)

### 멤버 관리
- **POST** `/api/crew/member/role/{crewId}` - 크루원 권한 수정 (크루장/매니저 전용)
- **POST** `/api/crew/ban/{crewId}` - 크루원 차단 (크루장/매니저 전용)
- **GET** `/api/crew/list/pending/{crewId}` - 가입 요청자 목록 조회 (크루장/매니저 전용)
- **GET** `/api/crew/list/banned/{crewId}` - 차단된 멤버 목록 조회 (크루장/매니저 전용)
- **GET** `/api/crew/member/{memberId}` - 유저 프로필 조회

## 권한 시스템
- **크루장 (CREW_LEADER)**: 모든 크루 관리 권한
- **크루 매니저 (CREW_MANAGER)**: 멤버 관리 및 가입 승인 권한
- **크루원 (CREW_MEMBER)**: 기본 참여 권한
- **일반 유저 (USER)**: 크루 조회 및 가입 신청 권한

## 보안 및 검증
- 모든 API JWT 인증 필수
- 역할 기반 접근 제어 구현
- 크루장의 크루 나가기 방지
- 중복 가입 및 크루 생성 방지
- 차단된 사용자의 재가입 방지

## 주요 DTO 구조
- `CrewCreateDTO`: 크루 생성 요청/응답
- `CrewDetailDTO`: 크루 상세 정보 
- `CrewListDTO`: 크루 목록 조회
- `CrewManagementDTO`: 가입 요청자/차단 멤버 관리
- `MemberProfileDTO`: 크루 사용자 프로필 정보
- `CrewApprovalDTO`: 가입 승인/거절 처리

## 예외 처리 시스템
총 18가지 커스텀 예외로 모든 edge case 처리
- 크루 관련: 생성, 조회, 권한, 중복 등
- 멤버 관리: 권한, 차단, 추방 등
- 가입 프로세스: 신청, 승인, 취소 등

## 데이터베이스 
- `crew` 테이블: 크루 기본 정보
- `crew_member` 테이블: 크루 멤버십 관리
- 상태 관리: ACTIVE, PENDING, BANNED