### PR TITLE
Feat: [Crew] 크루 런닝 및 크루/크루원 랭킹 구현

### DIFF
--- a/runtracker/src/main/java/com/runtracker/domain/course/controller/CourseController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/controller/CourseController.java
@@ -76,6 +76,20 @@ public class CourseController {
         }
     }
 
+    @PostMapping("/{courseId}/running")
+    public ApiResponse<Void> startRunningWithCourse(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long courseId) {
+        try {
+            courseService.startRunningCourse(userDetails.getMemberId(), courseId);
+            return ApiResponse.ok();
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getResponseCode());
+        } catch (Exception e) {
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     @PostMapping("/finish")
     public ApiResponse<Void> finishRunning(
             @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/runtracker/src/main/java/com/runtracker/domain/course/controller/CourseController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/controller/CourseController.java
@@ -4,6 +4,7 @@ import com.runtracker.domain.course.dto.CourseDTO;
 import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Request;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Response;
+import com.runtracker.domain.course.dto.FinishRunning;
 import com.runtracker.domain.course.service.CourseService;
 import com.runtracker.global.code.CommonResponseCode;
 import com.runtracker.global.exception.CustomException;
@@ -68,6 +69,20 @@ public class CourseController {
         try {
             CourseDetailDTO courseDetail = courseService.getCourseDetail(courseId);
             return ApiResponse.ok(courseDetail);
+        } catch (CustomException e) {
+            return ApiResponse.error(e.getResponseCode());
+        } catch (Exception e) {
+            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/finish")
+    public ApiResponse<Void> finishRunning(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody FinishRunning request) {
+        try {
+            courseService.finishRunning(userDetails.getMemberId(), request);
+            return ApiResponse.ok();
         } catch (CustomException e) {
             return ApiResponse.error(e.getResponseCode());
         } catch (Exception e) {

--- a/runtracker/src/main/java/com/runtracker/domain/course/dto/FinishRunning.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/dto/FinishRunning.java
@@ -1,0 +1,16 @@
+package com.runtracker.domain.course.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinishRunning {
+    private Double distance;
+    private Integer walk;
+    private Integer calorie;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/course/enums/CourseErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/enums/CourseErrorCode.java
@@ -12,7 +12,10 @@ public enum CourseErrorCode implements ResponseCode {
     COURSE_SAVE_FAILED("CR002", "Course save failed"),
     NEARBY_COURSE_MAPPING_FAILED("CR003", "Nearby course mapping failed"),
     COORDINATES_PARSING_FAILED("CR004", "Coordinates parsing failed"),
-    COURSE_NOT_FOUND("CR005", "Course not found");
+    COURSE_NOT_FOUND("CR005", "Course not found"),
+    VALIDATION_ERROR("CR006", "validation error"),
+    MULTIPLE_ACTIVE_RUNNING("CR007", "Multiple active running found"),
+    ALREADY_RUNNING("CR008", "Already running");
     
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/course/exception/AlreadyRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/exception/AlreadyRunningException.java
@@ -1,0 +1,11 @@
+package com.runtracker.domain.course.exception;
+
+import com.runtracker.domain.course.enums.CourseErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class AlreadyRunningException extends CustomException {
+    
+    public AlreadyRunningException(String message) {
+        super(CourseErrorCode.ALREADY_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/course/exception/MultipleActiveRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/exception/MultipleActiveRunningException.java
@@ -1,0 +1,11 @@
+package com.runtracker.domain.course.exception;
+
+import com.runtracker.domain.course.enums.CourseErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class MultipleActiveRunningException extends CustomException {
+    
+    public MultipleActiveRunningException(String message) {
+        super(CourseErrorCode.MULTIPLE_ACTIVE_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/course/exception/ValidationException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/exception/ValidationException.java
@@ -1,0 +1,11 @@
+package com.runtracker.domain.course.exception;
+
+import com.runtracker.domain.course.enums.CourseErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class ValidationException extends CustomException {
+    
+    public ValidationException(String message) {
+        super(CourseErrorCode.VALIDATION_ERROR, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/course/service/CourseService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/service/CourseService.java
@@ -27,6 +27,16 @@ public class CourseService {
 
     public void createFreeRunningCourse(CourseDTO courseDTO) {
         try {
+            createCourseFromDTO(courseDTO);
+        } catch (Exception e) {
+            log.error("Failed to create free running course for member: {}, error: {}", 
+                    courseDTO.getMemberId(), e.getMessage(), e);
+            throw new CourseCreationFailedException();
+        }
+    }
+
+    public Course createCourseFromDTO(CourseDTO courseDTO) {
+        try {
             Course course = Course.builder()
                     .memberId(courseDTO.getMemberId())
                     .name(courseDTO.getName())
@@ -43,10 +53,10 @@ public class CourseService {
                     .photoLng(courseDTO.getPhotoLng())
                     .build();
 
-            courseRepository.save(course);
+            return courseRepository.save(course);
             
         } catch (Exception e) {
-            log.error("Failed to create free running course for member: {}, error: {}", 
+            log.error("Failed to create course from DTO for member: {}, error: {}", 
                     courseDTO.getMemberId(), e.getMessage(), e);
             throw new CourseCreationFailedException("Failed to create course for member: " + courseDTO.getMemberId());
         }
@@ -68,7 +78,7 @@ public class CourseService {
         return convertToCourseDetailDTO(course);
     }
 
-    private CourseDetailDTO convertToCourseDetailDTO(Course course) {
+    public CourseDetailDTO convertToCourseDetailDTO(Course course) {
         return CourseDetailDTO.builder()
                 .id(course.getId())
                 .memberId(course.getMemberId())

--- a/runtracker/src/main/java/com/runtracker/domain/course/service/CourseService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/course/service/CourseService.java
@@ -4,16 +4,29 @@ import com.runtracker.domain.course.dto.CourseDTO;
 import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Request;
 import com.runtracker.domain.course.dto.NearbyCoursesDTO.Response;
+import com.runtracker.domain.course.dto.FinishRunning;
 import com.runtracker.domain.course.entity.Course;
-import com.runtracker.domain.course.entity.converter.CoordinatesConverter;
+import com.runtracker.domain.course.exception.AlreadyRunningException;
 import com.runtracker.domain.course.exception.CourseCreationFailedException;
 import com.runtracker.domain.course.exception.CourseNotFoundException;
+import com.runtracker.domain.course.exception.MultipleActiveRunningException;
+import com.runtracker.domain.course.exception.ValidationException;
 import com.runtracker.domain.course.repository.CourseRepository;
+import com.runtracker.domain.member.entity.Member;
+import com.runtracker.domain.member.exception.MemberNotFoundException;
+import com.runtracker.domain.member.repository.MemberRepository;
+import com.runtracker.domain.member.service.TempCalcService;
+import com.runtracker.domain.record.entity.RunningRecord;
+import com.runtracker.domain.record.exception.CourseNotFoundForRecordException;
+import com.runtracker.domain.record.exception.RecordNotFoundException;
+import com.runtracker.domain.record.repository.RecordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -23,15 +36,65 @@ import java.util.List;
 public class CourseService {
     
     private final CourseRepository courseRepository;
-    private final CoordinatesConverter coordinatesConverter = new CoordinatesConverter();
+    private final MemberRepository memberRepository;
+    private final RecordRepository recordRepository;
+    private final TempCalcService temperatureCalculationService;
 
     public void createFreeRunningCourse(CourseDTO courseDTO) {
+        validateCourseDTO(courseDTO);
+
+        List<RunningRecord> activeRecords = recordRepository.findAllByMemberIdAndFinishedAtIsNull(courseDTO.getMemberId());
+        if (!activeRecords.isEmpty()) {
+            throw new AlreadyRunningException("Member already has active running record");
+        }
+
         try {
-            createCourseFromDTO(courseDTO);
+            Course course = createCourseFromDTO(courseDTO);
+            
+            RunningRecord runningRecord = RunningRecord.builder()
+                    .memberId(courseDTO.getMemberId())
+                    .courseId(course.getId())
+                    .runningTime(null)
+                    .startedAt(LocalDateTime.now())
+                    .finishedAt(null)
+                    .distance(null)
+                    .walk(null)
+                    .calorie(null)
+                    .build();
+
+            recordRepository.save(runningRecord);
         } catch (Exception e) {
             log.error("Failed to create free running course for member: {}, error: {}", 
                     courseDTO.getMemberId(), e.getMessage(), e);
             throw new CourseCreationFailedException();
+        }
+    }
+
+    private void validateCourseDTO(CourseDTO courseDTO) {
+        if (courseDTO.getName() == null || courseDTO.getName().trim().isEmpty()) {
+            throw new ValidationException("Course name is required");
+        }
+        
+        if (courseDTO.getDifficulty() == null) {
+            throw new ValidationException("Course difficulty is required");
+        }
+        
+        if (courseDTO.getPoints() == null || courseDTO.getPoints().isEmpty()) {
+            throw new ValidationException("Course points are required");
+        }
+    }
+
+    private void validateFinishRunning(FinishRunning finishRunning) {
+        if (finishRunning.getDistance() == null || finishRunning.getDistance() < 0) {
+            throw new ValidationException("Distance is required and must be non-negative");
+        }
+        
+        if (finishRunning.getWalk() == null || finishRunning.getWalk() < 0) {
+            throw new ValidationException("Walk is required and must be non-negative");
+        }
+        
+        if (finishRunning.getCalorie() == null || finishRunning.getCalorie() < 0) {
+            throw new ValidationException("Calorie is required and must be non-negative");
         }
     }
 
@@ -96,5 +159,56 @@ public class CourseService {
                 .createdAt(course.getCreatedAt())
                 .updatedAt(course.getUpdatedAt())
                 .build();
+    }
+
+    @Transactional
+    public void finishRunning(Long memberId, FinishRunning finishRunning) {
+        validateFinishRunning(finishRunning);
+
+        // Todo: 나중에 런닝 상태 관리를 제대로 하고 싶으면 개인 러닝 상태관리 테이블을 하나 만들기 (findAllByMemberIdAndFinishedAtIsNull 대신에)
+        List<RunningRecord> activeRecords = recordRepository.findAllByMemberIdAndFinishedAtIsNull(memberId);
+        
+        if (activeRecords.isEmpty()) {
+            throw new RecordNotFoundException("No active running record found for member: " + memberId);
+        }
+        
+        if (activeRecords.size() > 1) {
+            throw new MultipleActiveRunningException("Multiple active running records found for member: " + memberId);
+        }
+        
+        RunningRecord existingRecord = activeRecords.get(0);
+
+        LocalDateTime finishedAt = LocalDateTime.now();
+        LocalDateTime startedAt = existingRecord.getStartedAt();
+        
+        long runningTimeSeconds = Duration.between(startedAt, finishedAt).getSeconds();
+        
+        Long courseId = existingRecord.getCourseId();
+        
+        existingRecord.updateFinishRunning(
+                (int) runningTimeSeconds,
+                finishedAt,
+                finishRunning.getDistance(),
+                finishRunning.getWalk(),
+                finishRunning.getCalorie()
+        );
+
+        recordRepository.save(existingRecord);
+
+        if (courseId != null) {
+            Course course = courseRepository.findById(courseId)
+                    .orElseThrow(() -> new CourseNotFoundForRecordException("Course not found with id: " + courseId));
+
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new MemberNotFoundException("Member not found with id: " + memberId));
+
+            double newTemperature = temperatureCalculationService.calculateNewTemperature(
+                    member.getTemperature(), finishRunning.getDistance(), course.getDistance());
+
+            double roundedTemperature = Math.round(newTemperature * 10.0) / 10.0;
+
+            member.updateTemperature(roundedTemperature);
+            memberRepository.save(member);
+        }
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -15,9 +15,11 @@ import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
 import com.runtracker.domain.crew.dto.CrewUpdateDTO;
 import com.runtracker.domain.crew.dto.MemberProfileDTO;
 import com.runtracker.domain.crew.dto.CrewRankingDTO;
+import com.runtracker.domain.crew.dto.CrewMemberRankingDTO;
 import com.runtracker.domain.crew.service.CrewService;
 import com.runtracker.domain.crew.service.CrewRunningService;
 import com.runtracker.domain.crew.service.CrewRankingService;
+import com.runtracker.domain.crew.service.CrewMemberRankingService;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,7 @@ public class CrewController {
     private final CrewService crewService;
     private final CrewRunningService crewRunningService;
     private final CrewRankingService crewRankingService;
+    private final CrewMemberRankingService crewMemberRankingService;
 
     @PostMapping("/create")
     public ApiResponse<Void> createCrew(
@@ -340,4 +343,25 @@ public class CrewController {
         return ApiResponse.ok();
     }
 
+    @GetMapping("/{crewId}/member-ranking")
+    public ApiResponse<CrewMemberRankingDTO.Response> getCrewMemberRanking(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        LocalDate today = LocalDate.now();
+        CrewMemberRankingDTO.Response response = crewMemberRankingService.getCrewMemberRanking(crewId, today);
+        
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/{crewId}/member-ranking/recalculate")
+    public ApiResponse<Void> recalculateCrewMemberRanking(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        LocalDate today = LocalDate.now();
+        crewMemberRankingService.recalculateCrewMemberRanking(crewId, today);
+        
+        return ApiResponse.ok();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -3,6 +3,7 @@ package com.runtracker.domain.crew.controller;
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCourseRecommendationDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
+import com.runtracker.domain.crew.dto.CrewRunningDTO;
 import com.runtracker.domain.crew.dto.CrewDetailDTO;
 import com.runtracker.domain.crew.dto.CrewListDTO;
 import com.runtracker.domain.crew.dto.CrewManagementDTO;
@@ -184,5 +185,70 @@ public class CrewController {
                 crewRunningService.getRecommendedCourses(crewId, region, minDistance, maxDistance, userDetails);
 
         return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/{crewId}/running/create")
+    public ApiResponse<Void> createCrewRunning(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @RequestBody CrewRunningDTO.CreateRequest request) {
+        
+        crewRunningService.createCrewRunning(crewId, request, userDetails);
+        
+        return ApiResponse.ok();
+    }
+
+    @GetMapping("/{crewId}/running/list")
+    public ApiResponse<List<CrewRunningDTO.Response>> getCrewRunnings(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        List<CrewRunningDTO.Response> response = crewRunningService.getCrewRunnings(crewId, userDetails);
+        
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/{crewId}/running/{crewRunningId}/join")
+    public ApiResponse<Void> joinCrewRunning(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId) {
+        
+        crewRunningService.joinCrewRunning(crewId, crewRunningId, userDetails);
+        
+        return ApiResponse.ok();
+    }
+
+    @PostMapping("/{crewId}/running/{crewRunningId}/leave")
+    public ApiResponse<Void> leaveCrewRunning(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId) {
+        
+        crewRunningService.leaveCrewRunning(crewId, crewRunningId, userDetails);
+        
+        return ApiResponse.ok();
+    }
+
+    @GetMapping("/{crewId}/running/list/{crewRunningId}")
+    public ApiResponse<CrewRunningDTO.Response> getCrewRunningDetail(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId) {
+        
+        CrewRunningDTO.Response response = crewRunningService.getCrewRunningDetail(crewId, crewRunningId, userDetails);
+        
+        return ApiResponse.ok(response);
+    }
+
+    @DeleteMapping("/{crewId}/running/{crewRunningId}")
+    public ApiResponse<Void> deleteCrewRunning(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId) {
+        
+        crewRunningService.deleteCrewRunning(crewId, crewRunningId, userDetails);
+        
+        return ApiResponse.ok();
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -5,6 +5,7 @@ import com.runtracker.domain.crew.dto.CrewCourseRecommendationDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
 import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.CourseDTO;
+import com.runtracker.domain.crew.dto.CrewRunningFinishDTO;
 import com.runtracker.domain.crew.dto.CrewRunningDTO;
 import com.runtracker.domain.crew.dto.CrewDetailDTO;
 import com.runtracker.domain.crew.dto.CrewListDTO;
@@ -277,6 +278,18 @@ public class CrewController {
             @RequestBody CourseDTO courseDTO) {
         
         crewRunningService.startCrewFreeRunning(crewId, crewRunningId, courseDTO, userDetails);
+        
+        return ApiResponse.ok();
+    }
+
+    @PostMapping("/{crewId}/running/{crewRunningId}/finish")
+    public ApiResponse<Void> finishCrewRunning(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId,
+            @RequestBody CrewRunningFinishDTO finishDTO) {
+        
+        crewRunningService.finishCrewRunning(crewId, crewRunningId, finishDTO, userDetails);
         
         return ApiResponse.ok();
     }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -1,6 +1,7 @@
 package com.runtracker.domain.crew.controller;
 
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
+import com.runtracker.domain.crew.dto.CrewCourseRecommendationDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
 import com.runtracker.domain.crew.dto.CrewDetailDTO;
 import com.runtracker.domain.crew.dto.CrewListDTO;
@@ -9,12 +10,15 @@ import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
 import com.runtracker.domain.crew.dto.CrewUpdateDTO;
 import com.runtracker.domain.crew.dto.MemberProfileDTO;
 import com.runtracker.domain.crew.service.CrewService;
+import com.runtracker.domain.crew.service.CrewRunningService;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class CrewController {
 
     private final CrewService crewService;
+    private final CrewRunningService crewRunningService;
 
     @PostMapping("/create")
     public ApiResponse<Void> createCrew(
@@ -164,6 +169,20 @@ public class CrewController {
         
         MemberProfileDTO response = crewService.getMemberProfile(memberId, userDetails);
         
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/{crewId}/recommended-courses")
+    public ApiResponse<List<CrewCourseRecommendationDTO.Response>> getRecommendedCourses(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) Double minDistance,
+            @RequestParam(required = false) Double maxDistance) {
+
+        List<CrewCourseRecommendationDTO.Response> response = 
+                crewRunningService.getRecommendedCourses(crewId, region, minDistance, maxDistance, userDetails);
+
         return ApiResponse.ok(response);
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -3,6 +3,8 @@ package com.runtracker.domain.crew.controller;
 import com.runtracker.domain.crew.dto.CrewApprovalDTO;
 import com.runtracker.domain.crew.dto.CrewCourseRecommendationDTO;
 import com.runtracker.domain.crew.dto.CrewCreateDTO;
+import com.runtracker.domain.course.dto.CourseDetailDTO;
+import com.runtracker.domain.course.dto.CourseDTO;
 import com.runtracker.domain.crew.dto.CrewRunningDTO;
 import com.runtracker.domain.crew.dto.CrewDetailDTO;
 import com.runtracker.domain.crew.dto.CrewListDTO;
@@ -251,4 +253,32 @@ public class CrewController {
         
         return ApiResponse.ok();
     }
+
+    @PostMapping("/{crewId}/running/{crewRunningId}/course/{courseId}")
+    public ApiResponse<CourseDetailDTO> startCrewRunningWithCourse(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId,
+            @PathVariable Long courseId) {
+        
+        CrewRunningDTO.StartRunningWithCourseRequest request = CrewRunningDTO.StartRunningWithCourseRequest.builder()
+                .courseId(courseId)
+                .build();
+        CourseDetailDTO courseDetail = crewRunningService.startCrewRunningWithCourse(crewId, crewRunningId, request, userDetails);
+        
+        return ApiResponse.ok(courseDetail);
+    }
+
+    @PostMapping("/{crewId}/running/{crewRunningId}/free-running")
+    public ApiResponse<Void> startCrewFreeRunning(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId,
+            @RequestBody CourseDTO courseDTO) {
+        
+        crewRunningService.startCrewFreeRunning(crewId, crewRunningId, courseDTO, userDetails);
+        
+        return ApiResponse.ok();
+    }
+
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -6,6 +6,7 @@ import com.runtracker.domain.crew.dto.CrewCreateDTO;
 import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.CourseDTO;
 import com.runtracker.domain.crew.dto.CrewRunningFinishDTO;
+import com.runtracker.domain.crew.dto.CrewRecordDTO;
 import com.runtracker.domain.crew.dto.CrewRunningDTO;
 import com.runtracker.domain.crew.dto.CrewDetailDTO;
 import com.runtracker.domain.crew.dto.CrewListDTO;
@@ -292,6 +293,27 @@ public class CrewController {
         crewRunningService.finishCrewRunning(crewId, crewRunningId, finishDTO, userDetails);
         
         return ApiResponse.ok();
+    }
+
+    @GetMapping("/{crewId}/records")
+    public ApiResponse<List<CrewRecordDTO>> getCrewRecords(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId) {
+        
+        List<CrewRecordDTO> response = crewService.getCrewRecords(crewId, userDetails);
+        
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/{crewId}/records/{crewRunningId}")
+    public ApiResponse<CrewRecordDTO> getCrewRecord(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long crewId,
+            @PathVariable Long crewRunningId) {
+        
+        CrewRecordDTO response = crewService.getCrewRecord(crewId, crewRunningId, userDetails);
+        
+        return ApiResponse.ok(response);
     }
 
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/controller/CrewController.java
@@ -14,8 +14,10 @@ import com.runtracker.domain.crew.dto.CrewManagementDTO;
 import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
 import com.runtracker.domain.crew.dto.CrewUpdateDTO;
 import com.runtracker.domain.crew.dto.MemberProfileDTO;
+import com.runtracker.domain.crew.dto.CrewRankingDTO;
 import com.runtracker.domain.crew.service.CrewService;
 import com.runtracker.domain.crew.service.CrewRunningService;
+import com.runtracker.domain.crew.service.CrewRankingService;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -33,6 +36,7 @@ public class CrewController {
 
     private final CrewService crewService;
     private final CrewRunningService crewRunningService;
+    private final CrewRankingService crewRankingService;
 
     @PostMapping("/create")
     public ApiResponse<Void> createCrew(
@@ -314,6 +318,26 @@ public class CrewController {
         CrewRecordDTO response = crewService.getCrewRecord(crewId, crewRunningId, userDetails);
         
         return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/ranking/list")
+    public ApiResponse<CrewRankingDTO.Response> getCurrentRanking(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        
+        LocalDate today = LocalDate.now();
+        CrewRankingDTO.Response response = crewRankingService.getDailyRanking(today);
+        
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/ranking/recalculate")
+    public ApiResponse<Void> recalculateRanking(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        
+        LocalDate today = LocalDate.now();
+        crewRankingService.recalculateRanking(today);
+        
+        return ApiResponse.ok();
     }
 
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewCourseRecommendationDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewCourseRecommendationDTO.java
@@ -1,0 +1,39 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.course.enums.Difficulty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CrewCourseRecommendationDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private String region;
+        private Double minDistance;
+        private Double maxDistance;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private Long courseId;
+        private String name;
+        private String region;
+        private Double distance;
+        private Difficulty difficulty;
+        private Double startLat;
+        private Double startLng;
+        private String photo;
+        private LocalDateTime createdAt;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewMemberRankingDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewMemberRankingDTO.java
@@ -1,0 +1,36 @@
+package com.runtracker.domain.crew.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CrewMemberRankingDTO {
+
+    @Getter
+    @Builder
+    public static class Response {
+        private LocalDate date;
+        private Long crewId;
+        private String crewName;
+        private List<MemberRankInfo> rankings;
+        private LocalDateTime lastUpdated;
+    }
+
+    @Getter
+    @Builder
+    public static class MemberRankInfo {
+        private Long memberId;
+        private String memberName;
+        private String memberPhoto;
+        private Integer rank;
+        private Double totalDistance;
+        private Integer totalRunningTime;
+        private Integer participationCount;
+        private Double averageDistance;
+        private Integer averageRunningTime;
+    }
+
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRankingDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRankingDTO.java
@@ -1,0 +1,43 @@
+package com.runtracker.domain.crew.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.runtracker.domain.crew.entity.CrewRanking;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CrewRankingDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CrewRankInfo {
+        private Long crewId;
+        private String crewName;
+        private String crewPhoto;
+        private Double totalDistance;
+        private Integer totalRunningTime;
+        private Integer rank;
+        private Integer participantCount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private LocalDate date;
+        private List<CrewRankInfo> rankings;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime lastUpdated;
+        
+    }
+
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRankingData.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRankingData.java
@@ -1,0 +1,22 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.crew.entity.CrewRecord;
+import lombok.Getter;
+
+@Getter
+public class CrewRankingData {
+    private final Long crewId;
+    private double totalDistance = 0.0;
+    private int totalRunningTime = 0;
+    private int participantCount = 0;
+
+    public CrewRankingData(Long crewId) {
+        this.crewId = crewId;
+    }
+
+    public void addRecord(CrewRecord record) {
+        this.totalDistance += record.getDistance();
+        this.totalRunningTime += record.getRunningTime();
+        this.participantCount++;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRecordDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRecordDTO.java
@@ -1,0 +1,50 @@
+package com.runtracker.domain.crew.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.runtracker.domain.crew.entity.CrewRecord;
+import com.runtracker.global.code.DateConstants;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CrewRecordDTO {
+    
+    private Long id;
+    private Long crewRunningId;
+    private Long courseId;
+    private Integer runningTime; // 평균 런닝 시간 (초 단위)
+    
+    @DateTimeFormat(pattern = DateConstants.DATETIME_PATTERN)
+    @JsonFormat(pattern = DateConstants.DATETIME_PATTERN)
+    private LocalDateTime startedAt; // 크루 런닝 시작 시간
+    
+    @DateTimeFormat(pattern = DateConstants.DATETIME_PATTERN)
+    @JsonFormat(pattern = DateConstants.DATETIME_PATTERN)
+    private LocalDateTime finishedAt; // 크루 런닝 완료 시간
+    
+    private Double distance;
+    private Double walk;
+    private Double calorie;
+    private Integer participantCount;
+    
+    public static CrewRecordDTO from(CrewRecord crewRecord) {
+        return new CrewRecordDTO(
+                crewRecord.getId(),
+                crewRecord.getCrewRunningId(),
+                crewRecord.getCourseId(),
+                crewRecord.getRunningTime(),
+                crewRecord.getStartedAt(),
+                crewRecord.getFinishedAt(),
+                crewRecord.getDistance(),
+                crewRecord.getWalk(),
+                crewRecord.getCalorie(),
+                crewRecord.getParticipantCount()
+        );
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRecordDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRecordDTO.java
@@ -18,15 +18,15 @@ public class CrewRecordDTO {
     private Long id;
     private Long crewRunningId;
     private Long courseId;
-    private Integer runningTime; // 평균 런닝 시간 (초 단위)
+    private Integer runningTime;
     
     @DateTimeFormat(pattern = DateConstants.DATETIME_PATTERN)
     @JsonFormat(pattern = DateConstants.DATETIME_PATTERN)
-    private LocalDateTime startedAt; // 크루 런닝 시작 시간
+    private LocalDateTime startedAt;
     
     @DateTimeFormat(pattern = DateConstants.DATETIME_PATTERN)
     @JsonFormat(pattern = DateConstants.DATETIME_PATTERN)
-    private LocalDateTime finishedAt; // 크루 런닝 완료 시간
+    private LocalDateTime finishedAt;
     
     private Double distance;
     private Double walk;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRunningDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRunningDTO.java
@@ -1,5 +1,7 @@
 package com.runtracker.domain.crew.dto;
 
+import com.runtracker.domain.course.enums.Difficulty;
+import com.runtracker.domain.course.entity.vo.Coordinate;
 import com.runtracker.domain.crew.enums.CrewRunningStatus;
 import com.runtracker.domain.crew.enums.ParticipantStatus;
 import lombok.*;
@@ -17,6 +19,35 @@ public class CrewRunningDTO {
     public static class CreateRequest {
         private String title;
         private String description;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StartRunningWithCourseRequest {
+        private Long courseId;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StartFreeRunningRequest {
+        private String name;
+        private Difficulty difficulty;
+        private List<Coordinate> points;
+        private Double startLat;
+        private Double startLng;
+        private Double distance;
+        private Boolean round;
+        private String indexs;
+        private String region;
+        private String photo;
+        private Double photoLat;
+        private Double photoLng;
     }
 
     @Getter

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRunningDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRunningDTO.java
@@ -1,0 +1,55 @@
+package com.runtracker.domain.crew.dto;
+
+import com.runtracker.domain.crew.enums.CrewRunningStatus;
+import com.runtracker.domain.crew.enums.ParticipantStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CrewRunningDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateRequest {
+        private String title;
+        private String description;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private Long id;
+        private Long crewId;
+        private Long creatorId;
+        private String creatorName;
+        private CrewRunningStatus status;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private String title;
+        private String description;
+        private List<ParticipantInfo> participants;
+        private LocalDateTime createdAt;
+    }
+
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ParticipantInfo {
+        private Long memberId;
+        private String memberName;
+        private ParticipantStatus status;
+        private LocalDateTime joinedAt;
+        private LocalDateTime startedAt;
+        private LocalDateTime finishedAt;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRunningFinishDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/CrewRunningFinishDTO.java
@@ -1,0 +1,15 @@
+package com.runtracker.domain.crew.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CrewRunningFinishDTO {
+    
+    private Double distance;
+    private Integer walk;
+    private Integer calorie;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/dto/MemberRankingData.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/dto/MemberRankingData.java
@@ -1,0 +1,21 @@
+package com.runtracker.domain.crew.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberRankingData {
+    private final Long memberId;
+    private double totalDistance = 0.0;
+    private int totalRunningTime = 0;
+    private int participationCount = 0;
+
+    public MemberRankingData(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public void addRecord(double distance, int runningTime) {
+        this.totalDistance += distance;
+        this.totalRunningTime += runningTime;
+        this.participationCount++;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMemberRanking.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewMemberRanking.java
@@ -1,0 +1,70 @@
+package com.runtracker.domain.crew.entity;
+
+import com.runtracker.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "crew_member_ranking")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CrewMemberRanking extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "crew_id", nullable = false)
+    private Long crewId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "rank_position", nullable = false)
+    private Integer rankPosition;
+
+    @Column(name = "total_distance", nullable = false)
+    private Double totalDistance;
+
+    @Column(name = "total_running_time", nullable = false)
+    private Integer totalRunningTime;
+
+    @Column(name = "participation_count", nullable = false)
+    private Integer participationCount;
+
+    @Builder
+    public CrewMemberRanking(LocalDate date, Long crewId, Long memberId, Integer rankPosition,
+                            Double totalDistance, Integer totalRunningTime, Integer participationCount) {
+        this.date = date;
+        this.crewId = crewId;
+        this.memberId = memberId;
+        this.rankPosition = rankPosition;
+        this.totalDistance = totalDistance;
+        this.totalRunningTime = totalRunningTime;
+        this.participationCount = participationCount;
+    }
+
+    public void updateRankPosition(Integer rankPosition) {
+        this.rankPosition = rankPosition;
+    }
+
+    public void addRunningRecord(Double distance, Integer runningTime) {
+        this.totalDistance += distance;
+        this.totalRunningTime += runningTime;
+        this.participationCount += 1;
+    }
+
+    public void updateTotalData(Double totalDistance, Integer totalRunningTime, Integer participationCount) {
+        this.totalDistance = totalDistance;
+        this.totalRunningTime = totalRunningTime;
+        this.participationCount = participationCount;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRanking.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRanking.java
@@ -1,0 +1,78 @@
+package com.runtracker.domain.crew.entity;
+
+import com.runtracker.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "crew_ranking")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CrewRanking extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "crew_id", nullable = false)
+    private Long crewId;
+
+    @Column(name = "rank_position", nullable = false)
+    private Integer rankPosition;
+
+    @Column(name = "total_distance", nullable = false)
+    private Double totalDistance;
+
+    @Column(name = "total_running_time", nullable = false)
+    private Integer totalRunningTime;
+
+    @Column(name = "participant_count", nullable = false)
+    private Integer participantCount;
+
+    @Builder
+    public CrewRanking(LocalDate date, Long crewId, Integer rankPosition, 
+                      Double totalDistance, Integer totalRunningTime, Integer participantCount) {
+        this.date = date;
+        this.crewId = crewId;
+        this.rankPosition = rankPosition;
+        this.totalDistance = totalDistance;
+        this.totalRunningTime = totalRunningTime;
+        this.participantCount = participantCount;
+    }
+
+    public void updateRankPosition(Integer rankPosition) {
+        this.rankPosition = rankPosition;
+    }
+
+    public void addCrewRecord(Double distance, Integer runningTime) {
+        this.totalDistance += distance;
+        this.totalRunningTime += runningTime;
+        this.participantCount += 1;
+    }
+
+    public void updateTotalData(Double totalDistance, Integer totalRunningTime, Integer participantCount) {
+        this.totalDistance = totalDistance;
+        this.totalRunningTime = totalRunningTime;
+        this.participantCount = participantCount;
+    }
+    
+    public void updateTotalDistance(Double totalDistance) {
+        this.totalDistance = totalDistance;
+    }
+    
+    public void updateTotalRunningTime(Integer totalRunningTime) {
+        this.totalRunningTime = totalRunningTime;
+    }
+    
+    public void updateParticipantCount(Integer participantCount) {
+        this.participantCount = participantCount;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRecord.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRecord.java
@@ -1,49 +1,47 @@
-package com.runtracker.domain.record.entity;
+package com.runtracker.domain.crew.entity;
 
 import com.runtracker.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Duration;
 
 @Entity
-@Table(name = "running_record")
+@Table(name = "crew_record")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class RunningRecord extends BaseEntity {
+public class CrewRecord extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @Column(name = "crew_running_id", nullable = false, unique = true)
+    private Long crewRunningId;
 
     @Column(name = "course_id", nullable = false)
     private Long courseId;
 
-    @Column(name = "crew_running_id")
-    private Long crewRunningId;
-
     @Column(name = "running_time")
     private Integer runningTime;
-    
-    @Column(name = "started_at")
-    private LocalDateTime startedAt;
-    
-    @Column(name = "finished_at")
-    private LocalDateTime finishedAt;
 
     @Column(name = "distance")
     private Double distance;
 
     @Column(name = "walk")
-    private Integer walk;
+    private Double walk;
 
     @Column(name = "calorie")
-    private Integer calorie;
+    private Double calorie;
+
+    @Column(name = "participant_count")
+    private Integer participantCount;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunning.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunning.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "crew_running")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -43,4 +44,14 @@ public class CrewRunning extends BaseEntity {
 
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
+
+    public void startRunning() {
+        this.status = CrewRunningStatus.IN_PROGRESS;
+        this.startTime = LocalDateTime.now();
+    }
+
+    public void finishRunning() {
+        this.status = CrewRunningStatus.COMPLETED;
+        this.endTime = LocalDateTime.now();
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunning.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunning.java
@@ -1,0 +1,46 @@
+package com.runtracker.domain.crew.entity;
+
+import com.runtracker.domain.crew.enums.CrewRunningStatus;
+import com.runtracker.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "crew_running")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CrewRunning extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "crew_id", nullable = false)
+    private Long crewId;
+
+    @Column(name = "course_id")
+    private Long courseId;
+
+    @Column(name = "creator_id", nullable = false)
+    private Long creatorId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private CrewRunningStatus status;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Column(name = "title", length = 100)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunningParticipant.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunningParticipant.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "crew_running_participant")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunningParticipant.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/entity/CrewRunningParticipant.java
@@ -1,0 +1,61 @@
+package com.runtracker.domain.crew.entity;
+
+import com.runtracker.domain.crew.enums.ParticipantStatus;
+import com.runtracker.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "crew_running_participant")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CrewRunningParticipant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "crew_running_id", nullable = false)
+    private Long crewRunningId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ParticipantStatus status;
+
+    @Column(name = "joined_at")
+    private LocalDateTime joinedAt;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+
+
+    public void joinRunning() {
+        this.status = ParticipantStatus.JOINED;
+        this.joinedAt = LocalDateTime.now();
+    }
+
+    public void startRunning() {
+        this.status = ParticipantStatus.RUNNING;
+        this.startedAt = LocalDateTime.now();
+    }
+
+    public void finishRunning() {
+        this.status = ParticipantStatus.FINISHED;
+        this.finishedAt = LocalDateTime.now();
+    }
+
+    public void leaveRunning() {
+        this.status = ParticipantStatus.LEFT;
+    }
+
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -33,7 +33,8 @@ public enum CrewErrorCode implements ResponseCode {
     CREW_RUNNING_JOIN_FAILED("CR023", "크루 런닝 참여에 실패했습니다."),
     NOT_JOINED_CREW_RUNNING("CR024", "참여하지 않은 크루 런닝입니다."),
     CANNOT_LEAVE_STARTED_RUNNING("CR025", "이미 시작된 크루 런닝은 나갈 수 없습니다."),
-    CANNOT_DELETE_STARTED_RUNNING("CR026", "이미 시작된 크루 런닝은 삭제할 수 없습니다.");
+    CANNOT_DELETE_STARTED_RUNNING("CR026", "이미 시작된 크루 런닝은 삭제할 수 없습니다."),
+    ALREADY_IN_ACTIVE_CREW_RUNNING("CR027", "이미 진행 중인 크루 런닝에 참여 중입니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -25,7 +25,15 @@ public enum CrewErrorCode implements ResponseCode {
     CANNOT_KICK_YOURSELF("CR015", "자기 자신을 추방할 수 없습니다."),
     CANNOT_KICK_MANAGER_AS_MANAGER("CR016", "매니저는 다른 매니저를 추방할 수 없습니다."),
     BANNED_FROM_CREW("CR017", "해당 크루에서 차단된 회원입니다."),
-    CANNOT_LEAVE_AS_CREW_LEADER("CR018", "크루장은 크루를 나갈 수 없습니다.");
+    CANNOT_LEAVE_AS_CREW_LEADER("CR018", "크루장은 크루를 나갈 수 없습니다."),
+    CREW_RUNNING_NOT_FOUND("CR019", "크루 런닝방을 찾을 수 없습니다."),
+    CREW_RUNNING_NOT_WAITING("CR020", "참여할 수 없는 크루 런닝 상태입니다."),
+    ALREADY_JOINED_CREW_RUNNING("CR021", "이미 참여한 크루 런닝입니다."),
+    CREW_RUNNING_CREATION_FAILED("CR022", "크루 런닝 생성에 실패했습니다."),
+    CREW_RUNNING_JOIN_FAILED("CR023", "크루 런닝 참여에 실패했습니다."),
+    NOT_JOINED_CREW_RUNNING("CR024", "참여하지 않은 크루 런닝입니다."),
+    CANNOT_LEAVE_STARTED_RUNNING("CR025", "이미 시작된 크루 런닝은 나갈 수 없습니다."),
+    CANNOT_DELETE_STARTED_RUNNING("CR026", "이미 시작된 크루 런닝은 삭제할 수 없습니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewErrorCode.java
@@ -34,7 +34,10 @@ public enum CrewErrorCode implements ResponseCode {
     NOT_JOINED_CREW_RUNNING("CR024", "참여하지 않은 크루 런닝입니다."),
     CANNOT_LEAVE_STARTED_RUNNING("CR025", "이미 시작된 크루 런닝은 나갈 수 없습니다."),
     CANNOT_DELETE_STARTED_RUNNING("CR026", "이미 시작된 크루 런닝은 삭제할 수 없습니다."),
-    ALREADY_IN_ACTIVE_CREW_RUNNING("CR027", "이미 진행 중인 크루 런닝에 참여 중입니다.");
+    ALREADY_IN_ACTIVE_CREW_RUNNING("CR027", "이미 진행 중인 크루 런닝에 참여 중입니다."),
+    CANNOT_FINISH_NOT_RUNNING("CR028", "런닝 중이 아닌 상태에서는 완료할 수 없습니다."),
+    ALREADY_FINISHED_CREW_RUNNING("CR029", "이미 완료된 크루 런닝입니다."),
+    UNAUTHORIZED_CREW_ACCESS("CR030", "크루에 대한 접근 권한이 없습니다.");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewRunningStatus.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/CrewRunningStatus.java
@@ -1,0 +1,8 @@
+package com.runtracker.domain.crew.enums;
+
+public enum CrewRunningStatus {
+    WAITING,      // 대기중
+    IN_PROGRESS,  // 진행중
+    COMPLETED,    // 완료
+    CANCELLED     // 취소됨
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/enums/ParticipantStatus.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/enums/ParticipantStatus.java
@@ -1,0 +1,8 @@
+package com.runtracker.domain.crew.enums;
+
+public enum ParticipantStatus {
+    JOINED,    // 참여함
+    RUNNING,   // 런닝중
+    FINISHED,  // 완주함
+    LEFT       // 중도 이탈
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyFinishedCrewRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyFinishedCrewRunningException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class AlreadyFinishedCrewRunningException extends CustomException {
+    public AlreadyFinishedCrewRunningException() {
+        super(CrewErrorCode.ALREADY_FINISHED_CREW_RUNNING);
+    }
+
+    public AlreadyFinishedCrewRunningException(String message) {
+        super(CrewErrorCode.ALREADY_FINISHED_CREW_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyInActiveCrewRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyInActiveCrewRunningException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class AlreadyInActiveCrewRunningException extends CustomException {
+    public AlreadyInActiveCrewRunningException() {
+        super(CrewErrorCode.ALREADY_IN_ACTIVE_CREW_RUNNING);
+    }
+
+    public AlreadyInActiveCrewRunningException(String message) {
+        super(CrewErrorCode.ALREADY_IN_ACTIVE_CREW_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyJoinedCrewRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/AlreadyJoinedCrewRunningException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class AlreadyJoinedCrewRunningException extends CustomException {
+    public AlreadyJoinedCrewRunningException() {
+        super(CrewErrorCode.ALREADY_JOINED_CREW_RUNNING);
+    }
+
+    public AlreadyJoinedCrewRunningException(String message) {
+        super(CrewErrorCode.ALREADY_JOINED_CREW_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotDeleteStartedRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotDeleteStartedRunningException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotDeleteStartedRunningException extends CustomException {
+    public CannotDeleteStartedRunningException() {
+        super(CrewErrorCode.CANNOT_DELETE_STARTED_RUNNING);
+    }
+
+    public CannotDeleteStartedRunningException(String message) {
+        super(CrewErrorCode.CANNOT_DELETE_STARTED_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotFinishNotRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotFinishNotRunningException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotFinishNotRunningException extends CustomException {
+    public CannotFinishNotRunningException() {
+        super(CrewErrorCode.CANNOT_FINISH_NOT_RUNNING);
+    }
+
+    public CannotFinishNotRunningException(String message) {
+        super(CrewErrorCode.CANNOT_FINISH_NOT_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotLeaveStartedRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CannotLeaveStartedRunningException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CannotLeaveStartedRunningException extends CustomException {
+    public CannotLeaveStartedRunningException() {
+        super(CrewErrorCode.CANNOT_LEAVE_STARTED_RUNNING);
+    }
+
+    public CannotLeaveStartedRunningException(String message) {
+        super(CrewErrorCode.CANNOT_LEAVE_STARTED_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningCreationFailedException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningCreationFailedException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewRunningCreationFailedException extends CustomException {
+    public CrewRunningCreationFailedException() {
+        super(CrewErrorCode.CREW_RUNNING_CREATION_FAILED);
+    }
+
+    public CrewRunningCreationFailedException(String message) {
+        super(CrewErrorCode.CREW_RUNNING_CREATION_FAILED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningJoinFailedException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningJoinFailedException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewRunningJoinFailedException extends CustomException {
+    public CrewRunningJoinFailedException() {
+        super(CrewErrorCode.CREW_RUNNING_JOIN_FAILED);
+    }
+
+    public CrewRunningJoinFailedException(String message) {
+        super(CrewErrorCode.CREW_RUNNING_JOIN_FAILED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningNotFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningNotFoundException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewRunningNotFoundException extends CustomException {
+    public CrewRunningNotFoundException() {
+        super(CrewErrorCode.CREW_RUNNING_NOT_FOUND);
+    }
+
+    public CrewRunningNotFoundException(String message) {
+        super(CrewErrorCode.CREW_RUNNING_NOT_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningNotWaitingException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/CrewRunningNotWaitingException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class CrewRunningNotWaitingException extends CustomException {
+    public CrewRunningNotWaitingException() {
+        super(CrewErrorCode.CREW_RUNNING_NOT_WAITING);
+    }
+
+    public CrewRunningNotWaitingException(String message) {
+        super(CrewErrorCode.CREW_RUNNING_NOT_WAITING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/NotJoinedCrewRunningException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/NotJoinedCrewRunningException.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class NotJoinedCrewRunningException extends CustomException {
+    public NotJoinedCrewRunningException() {
+        super(CrewErrorCode.NOT_JOINED_CREW_RUNNING);
+    }
+
+    public NotJoinedCrewRunningException(String message) {
+        super(CrewErrorCode.NOT_JOINED_CREW_RUNNING, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/exception/UnauthorizedCrewAccessException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/exception/UnauthorizedCrewAccessException.java
@@ -1,0 +1,11 @@
+package com.runtracker.domain.crew.exception;
+
+import com.runtracker.domain.crew.enums.CrewErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class UnauthorizedCrewAccessException extends CustomException {
+    
+    public UnauthorizedCrewAccessException() {
+        super(CrewErrorCode.UNAUTHORIZED_CREW_ACCESS);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRankingRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewMemberRankingRepository.java
@@ -1,0 +1,17 @@
+package com.runtracker.domain.crew.repository;
+
+import com.runtracker.domain.crew.entity.CrewMemberRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CrewMemberRankingRepository extends JpaRepository<CrewMemberRanking, Long> {
+
+    List<CrewMemberRanking> findByCrewIdAndDateOrderByRankPosition(Long crewId, LocalDate date);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRankingRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRankingRepository.java
@@ -1,0 +1,28 @@
+package com.runtracker.domain.crew.repository;
+
+import com.runtracker.domain.crew.entity.CrewRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CrewRankingRepository extends JpaRepository<CrewRanking, Long> {
+    
+    List<CrewRanking> findByDateOrderByRankPosition(LocalDate date);
+    
+    Optional<CrewRanking> findByDateAndCrewId(LocalDate date, Long crewId);
+    
+    List<CrewRanking> findByCrewIdOrderByDateDesc(Long crewId);
+    
+    @Query("SELECT cr FROM CrewRanking cr WHERE cr.date = :date AND cr.rankPosition <= :topN ORDER BY cr.rankPosition")
+    List<CrewRanking> findTopNByDate(@Param("date") LocalDate date, @Param("topN") int topN);
+    
+    List<CrewRanking> findByDateOrderByTotalDistanceDesc(LocalDate date);
+    
+    void deleteByDate(LocalDate date);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRecordRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRecordRepository.java
@@ -1,0 +1,13 @@
+package com.runtracker.domain.crew.repository;
+
+import com.runtracker.domain.crew.entity.CrewRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CrewRecordRepository extends JpaRepository<CrewRecord, Long> {
+    
+    Optional<CrewRecord> findByCrewRunningId(Long crewRunningId);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRecordRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRecordRepository.java
@@ -4,10 +4,13 @@ import com.runtracker.domain.crew.entity.CrewRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CrewRecordRepository extends JpaRepository<CrewRecord, Long> {
     
     Optional<CrewRecord> findByCrewRunningId(Long crewRunningId);
+    
+    List<CrewRecord> findByCrewRunningIdIn(List<Long> crewRunningIds);
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRunningParticipantRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRunningParticipantRepository.java
@@ -30,4 +30,6 @@ public interface CrewRunningParticipantRepository extends JpaRepository<CrewRunn
 
     @Query("SELECT COUNT(crp) FROM CrewRunningParticipant crp WHERE crp.crewRunningId = :crewRunningId")
     long countParticipantsByCrewRunningId(@Param("crewRunningId") Long crewRunningId);
+
+    List<CrewRunningParticipant> findByMemberIdAndStatusIn(Long memberId, List<ParticipantStatus> statuses);
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRunningParticipantRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRunningParticipantRepository.java
@@ -1,0 +1,33 @@
+package com.runtracker.domain.crew.repository;
+
+import com.runtracker.domain.crew.entity.CrewRunningParticipant;
+import com.runtracker.domain.crew.enums.ParticipantStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CrewRunningParticipantRepository extends JpaRepository<CrewRunningParticipant, Long> {
+
+    List<CrewRunningParticipant> findByCrewRunningIdOrderByJoinedAtAsc(Long crewRunningId);
+
+    List<CrewRunningParticipant> findByCrewRunningIdAndStatusOrderByJoinedAtAsc(Long crewRunningId, ParticipantStatus status);
+
+    Optional<CrewRunningParticipant> findByCrewRunningIdAndMemberId(Long crewRunningId, Long memberId);
+
+    List<CrewRunningParticipant> findByMemberIdOrderByJoinedAtDesc(Long memberId);
+
+    @Query("SELECT crp FROM CrewRunningParticipant crp WHERE crp.crewRunningId IN :crewRunningIds ORDER BY crp.joinedAt ASC")
+    List<CrewRunningParticipant> findByCrewRunningIds(@Param("crewRunningIds") List<Long> crewRunningIds);
+
+    long countByCrewRunningIdAndStatus(Long crewRunningId, ParticipantStatus status);
+
+    boolean existsByCrewRunningIdAndMemberId(Long crewRunningId, Long memberId);
+
+    @Query("SELECT COUNT(crp) FROM CrewRunningParticipant crp WHERE crp.crewRunningId = :crewRunningId")
+    long countParticipantsByCrewRunningId(@Param("crewRunningId") Long crewRunningId);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRunningRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/repository/CrewRunningRepository.java
@@ -1,0 +1,32 @@
+package com.runtracker.domain.crew.repository;
+
+import com.runtracker.domain.crew.entity.CrewRunning;
+import com.runtracker.domain.crew.enums.CrewRunningStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CrewRunningRepository extends JpaRepository<CrewRunning, Long> {
+
+    List<CrewRunning> findByCrewIdOrderByCreatedAtDesc(Long crewId);
+
+    List<CrewRunning> findByCrewIdAndStatusOrderByCreatedAtDesc(Long crewId, CrewRunningStatus status);
+
+    Optional<CrewRunning> findByIdAndCrewId(Long id, Long crewId);
+
+    @Query("SELECT cr FROM CrewRunning cr WHERE cr.crewId = :crewId AND cr.status IN :statuses ORDER BY cr.createdAt DESC")
+    List<CrewRunning> findByCrewIdAndStatusIn(@Param("crewId") Long crewId, @Param("statuses") List<CrewRunningStatus> statuses);
+
+    @Query("SELECT cr FROM CrewRunning cr WHERE cr.crewId = :crewId AND cr.createdAt >= :startDate AND cr.createdAt <= :endDate ORDER BY cr.createdAt DESC")
+    List<CrewRunning> findByCrewIdAndDateRange(@Param("crewId") Long crewId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    long countByCrewIdAndStatus(Long crewId, CrewRunningStatus status);
+
+    boolean existsByCrewIdAndStatus(Long crewId, CrewRunningStatus status);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewMemberRankingService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewMemberRankingService.java
@@ -1,0 +1,202 @@
+package com.runtracker.domain.crew.service;
+
+import com.runtracker.domain.crew.dto.CrewMemberRankingDTO;
+import com.runtracker.domain.crew.dto.MemberRankingData;
+import com.runtracker.domain.crew.entity.Crew;
+import com.runtracker.domain.crew.entity.CrewMember;
+import com.runtracker.domain.crew.entity.CrewMemberRanking;
+import com.runtracker.domain.crew.entity.CrewRunning;
+import com.runtracker.domain.crew.repository.*;
+import com.runtracker.domain.member.entity.Member;
+import com.runtracker.domain.member.repository.MemberRepository;
+import com.runtracker.domain.record.entity.RunningRecord;
+import com.runtracker.domain.record.repository.RecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CrewMemberRankingService {
+
+    private final CrewMemberRankingRepository crewMemberRankingRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final CrewRepository crewRepository;
+    private final CrewRunningRepository crewRunningRepository;
+    private final RecordRepository recordRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 특정 크루의 멤버 랭킹 조회
+     */
+    public CrewMemberRankingDTO.Response getCrewMemberRanking(Long crewId, LocalDate date) {
+        List<CrewMemberRanking> rankings = findExistingMemberRankings(crewId, date);
+        
+        if (rankings.isEmpty()) {
+            calculateCrewMemberRanking(crewId, date);
+            rankings = findExistingMemberRankings(crewId, date);
+        }
+        
+        return buildMemberRankingResponse(crewId, date, rankings);
+    }
+
+    /**
+     * 특정 크루의 멤버 랭킹 강제 재계산
+     */
+    public void recalculateCrewMemberRanking(Long crewId, LocalDate date) {
+        calculateCrewMemberRanking(crewId, date);
+    }
+
+    /**
+     * 크루 멤버 랭킹 계산
+     */
+    private void calculateCrewMemberRanking(Long crewId, LocalDate date) {
+        Map<Long, MemberRankingData> memberDataMap = calculateMemberRankingData(crewId, date);
+        saveOrUpdateMemberRankings(crewId, date, memberDataMap);
+    }
+
+    /**
+     * 크루 내 멤버별 누적 데이터 계산
+     */
+    private Map<Long, MemberRankingData> calculateMemberRankingData(Long crewId, LocalDate date) {
+        Map<Long, MemberRankingData> memberDataMap = new HashMap<>();
+        LocalDateTime endOfDay = date.atTime(23, 59, 59);
+
+        List<CrewRunning> crewRunnings = crewRunningRepository.findAll().stream()
+                .filter(cr -> cr.getCrewId().equals(crewId))
+                .filter(cr -> !cr.getCreatedAt().isAfter(endOfDay))
+                .toList();
+        
+        List<Long> crewRunningIds = crewRunnings.stream()
+                .map(CrewRunning::getId)
+                .toList();
+
+        List<RunningRecord> memberRecords = recordRepository.findAll().stream()
+                .filter(record -> crewRunningIds.contains(record.getCrewRunningId()))
+                .toList();
+
+        for (RunningRecord record : memberRecords) {
+            memberDataMap.computeIfAbsent(record.getMemberId(), MemberRankingData::new)
+                    .addRecord(record.getDistance(), record.getRunningTime());
+        }
+
+        includeAllCrewMembers(crewId, memberDataMap);
+        
+        return memberDataMap;
+    }
+
+    /**
+     * 계산된 데이터로 멤버 랭킹 저장
+     */
+    private void saveOrUpdateMemberRankings(Long crewId, LocalDate date, Map<Long, MemberRankingData> memberDataMap) {
+        Map<Long, CrewMemberRanking> existingRankings = getExistingMemberRankingsMap(crewId, date);
+        
+        List<MemberRankingData> sortedData = memberDataMap.values().stream()
+                .sorted((a, b) -> Double.compare(b.getTotalDistance(), a.getTotalDistance()))
+                .toList();
+
+        for (int i = 0; i < sortedData.size(); i++) {
+            MemberRankingData data = sortedData.get(i);
+            int rank = i + 1;
+            
+            CrewMemberRanking existing = existingRankings.get(data.getMemberId());
+            
+            if (existing == null) {
+                createNewMemberRanking(crewId, date, data, rank);
+            } else {
+                updateExistingMemberRanking(existing, data, rank);
+            }
+        }
+    }
+
+    private List<CrewMemberRanking> findExistingMemberRankings(Long crewId, LocalDate date) {
+        return crewMemberRankingRepository.findByCrewIdAndDateOrderByRankPosition(crewId, date);
+    }
+
+    private CrewMemberRankingDTO.Response buildMemberRankingResponse(Long crewId, LocalDate date, List<CrewMemberRanking> rankings) {
+        List<CrewMemberRankingDTO.MemberRankInfo> rankInfos = rankings.stream()
+                .map(this::convertToMemberRankInfo)
+                .toList();
+
+        Optional<Crew> crew = crewRepository.findById(crewId);
+        LocalDateTime lastUpdated = rankings.isEmpty() ? LocalDateTime.now() : 
+                rankings.stream()
+                        .map(CrewMemberRanking::getUpdatedAt)
+                        .max(LocalDateTime::compareTo)
+                        .orElse(LocalDateTime.now());
+
+        return CrewMemberRankingDTO.Response.builder()
+                .date(date)
+                .crewId(crewId)
+                .crewName(crew.map(Crew::getTitle).orElse("Unknown"))
+                .rankings(rankInfos)
+                .lastUpdated(lastUpdated)
+                .build();
+    }
+
+    private void includeAllCrewMembers(Long crewId, Map<Long, MemberRankingData> memberDataMap) {
+        crewMemberRepository.findByCrewId(crewId).stream()
+                .filter(crewMember -> !crewMember.getStatus().equals(com.runtracker.domain.crew.enums.CrewMemberStatus.BANNED))
+                .forEach(crewMember ->
+                        memberDataMap.putIfAbsent(crewMember.getMemberId(), new MemberRankingData(crewMember.getMemberId()))
+                );
+    }
+
+    private Map<Long, CrewMemberRanking> getExistingMemberRankingsMap(Long crewId, LocalDate date) {
+        return crewMemberRankingRepository.findByCrewIdAndDateOrderByRankPosition(crewId, date).stream()
+                .collect(Collectors.toMap(CrewMemberRanking::getMemberId, ranking -> ranking));
+    }
+
+    private void createNewMemberRanking(Long crewId, LocalDate date, MemberRankingData data, int rank) {
+        CrewMemberRanking newRanking = CrewMemberRanking.builder()
+                .date(date)
+                .crewId(crewId)
+                .memberId(data.getMemberId())
+                .rankPosition(rank)
+                .totalDistance(data.getTotalDistance())
+                .totalRunningTime(data.getTotalRunningTime())
+                .participationCount(data.getParticipationCount())
+                .build();
+        crewMemberRankingRepository.save(newRanking);
+    }
+
+    private void updateExistingMemberRanking(CrewMemberRanking existing, MemberRankingData data, int rank) {
+        boolean needsUpdate = !existing.getRankPosition().equals(rank) ||
+                Math.abs(existing.getTotalDistance() - data.getTotalDistance()) > 0.01 ||
+                !existing.getTotalRunningTime().equals(data.getTotalRunningTime()) ||
+                !existing.getParticipationCount().equals(data.getParticipationCount());
+        
+        if (needsUpdate) {
+            existing.updateRankPosition(rank);
+            existing.updateTotalData(data.getTotalDistance(), data.getTotalRunningTime(), data.getParticipationCount());
+            crewMemberRankingRepository.save(existing);
+        }
+    }
+
+    private CrewMemberRankingDTO.MemberRankInfo convertToMemberRankInfo(CrewMemberRanking ranking) {
+        Optional<Member> member = memberRepository.findById(ranking.getMemberId());
+        
+        double averageDistance = ranking.getParticipationCount() > 0 ? 
+                ranking.getTotalDistance() / ranking.getParticipationCount() : 0.0;
+        int averageRunningTime = ranking.getParticipationCount() > 0 ? 
+                ranking.getTotalRunningTime() / ranking.getParticipationCount() : 0;
+        
+        return CrewMemberRankingDTO.MemberRankInfo.builder()
+                .memberId(ranking.getMemberId())
+                .memberName(member.map(Member::getName).orElse("Unknown"))
+                .memberPhoto(member.map(Member::getPhoto).orElse(null))
+                .rank(ranking.getRankPosition())
+                .totalDistance(ranking.getTotalDistance())
+                .totalRunningTime(ranking.getTotalRunningTime())
+                .participationCount(ranking.getParticipationCount())
+                .averageDistance(averageDistance)
+                .averageRunningTime(averageRunningTime)
+                .build();
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewRankingService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewRankingService.java
@@ -1,0 +1,238 @@
+package com.runtracker.domain.crew.service;
+
+import com.runtracker.domain.crew.dto.CrewRankingDTO;
+import com.runtracker.domain.crew.dto.CrewRankingData;
+import com.runtracker.domain.crew.entity.Crew;
+import com.runtracker.domain.crew.entity.CrewRanking;
+import com.runtracker.domain.crew.entity.CrewRecord;
+import com.runtracker.domain.crew.entity.CrewRunning;
+import com.runtracker.domain.crew.repository.CrewRankingRepository;
+import com.runtracker.domain.crew.repository.CrewRecordRepository;
+import com.runtracker.domain.crew.repository.CrewRepository;
+import com.runtracker.domain.crew.repository.CrewRunningRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CrewRankingService {
+
+    private final CrewRankingRepository crewRankingRepository;
+    private final CrewRecordRepository crewRecordRepository;
+    private final CrewRepository crewRepository;
+    private final CrewRunningRepository crewRunningRepository;
+
+    /**
+     * 랭킹 조회
+     */
+    public CrewRankingDTO.Response getDailyRanking(LocalDate date) {
+        List<CrewRanking> rankings = findExistingRankings(date);
+        
+        if (rankings.isEmpty()) {
+            rankingCalculation(date);
+            rankings = findExistingRankings(date);
+        }
+        
+        return buildResponse(date, rankings);
+    }
+
+    /**
+     * 랭킹 강제 재계산
+     */
+    public void recalculateRanking(LocalDate date) {
+        rankingCalculation(date);
+    }
+
+    /**
+     * 크루 기록 추가 시 실시간 랭킹 업데이트
+     */
+    public void updateRankingForCrewRecord(Long crewId, LocalDate date, CrewRecord newRecord) {
+        updateOrCreateCrewRanking(crewId, date, newRecord);
+        reorderRankPositions(date);
+    }
+
+    /**
+     * 랭킹 계산
+     */
+    private void rankingCalculation(LocalDate date) {
+        Map<Long, CrewRankingData> crewDataMap = calculateCrewRankingData(date);
+        saveOrUpdateRankings(date, crewDataMap);
+    }
+
+    /**
+     * 크루별 누적 데이터 계산
+     */
+    private Map<Long, CrewRankingData> calculateCrewRankingData(LocalDate date) {
+        Map<Long, CrewRankingData> crewDataMap = new HashMap<>();
+
+        List<CrewRecord> records = getAllCrewRecordsUpToDate(date);
+
+        for (CrewRecord record : records) {
+            Long crewId = getCrewIdFromRecord(record);
+            if (crewId != null) {
+                crewDataMap.computeIfAbsent(crewId, CrewRankingData::new)
+                        .addRecord(record);
+            }
+        }
+        includeAllCrews(crewDataMap);
+        
+        return crewDataMap;
+    }
+
+    /**
+     * 계산된 데이터로 랭킹 저장/업데이트
+     */
+    private void saveOrUpdateRankings(LocalDate date, Map<Long, CrewRankingData> crewDataMap) {
+        Map<Long, CrewRanking> existingRankings = getExistingRankingsMap(date);
+        
+        List<CrewRankingData> sortedData = crewDataMap.values().stream()
+                .sorted((a, b) -> Double.compare(b.getTotalDistance(), a.getTotalDistance()))
+                .toList();
+
+        for (int i = 0; i < sortedData.size(); i++) {
+            CrewRankingData data = sortedData.get(i);
+            int rank = i + 1;
+            
+            CrewRanking existing = existingRankings.get(data.getCrewId());
+            
+            if (existing == null) {
+                createNewRanking(date, data, rank);
+            } else {
+                updateExistingRanking(existing, data, rank);
+            }
+        }
+    }
+
+    private List<CrewRanking> findExistingRankings(LocalDate date) {
+        return crewRankingRepository.findByDateOrderByRankPosition(date);
+    }
+
+    private CrewRankingDTO.Response buildResponse(LocalDate date, List<CrewRanking> rankings) {
+        List<CrewRankingDTO.CrewRankInfo> rankInfos = rankings.stream()
+                .map(this::convertToRankInfo)
+                .toList();
+
+        LocalDateTime lastUpdated = rankings.isEmpty() ? LocalDateTime.now() : 
+                rankings.stream()
+                        .map(CrewRanking::getUpdatedAt)
+                        .max(LocalDateTime::compareTo)
+                        .orElse(LocalDateTime.now());
+
+        return CrewRankingDTO.Response.builder()
+                .date(date)
+                .rankings(rankInfos)
+                .lastUpdated(lastUpdated)
+                .build();
+    }
+
+    private List<CrewRecord> getAllCrewRecordsUpToDate(LocalDate date) {
+        LocalDateTime endOfDay = date.atTime(23, 59, 59);
+        
+        List<Long> crewRunningIds = crewRunningRepository.findAll().stream()
+                .filter(cr -> !cr.getCreatedAt().isAfter(endOfDay))
+                .map(CrewRunning::getId)
+                .toList();
+        
+        return crewRecordRepository.findByCrewRunningIdIn(crewRunningIds);
+    }
+
+    private void includeAllCrews(Map<Long, CrewRankingData> crewDataMap) {
+        crewRepository.findAll().forEach(crew -> 
+            crewDataMap.putIfAbsent(crew.getId(), new CrewRankingData(crew.getId()))
+        );
+    }
+
+    private Map<Long, CrewRanking> getExistingRankingsMap(LocalDate date) {
+        return crewRankingRepository.findByDateOrderByRankPosition(date).stream()
+                .collect(Collectors.toMap(CrewRanking::getCrewId, ranking -> ranking));
+    }
+
+    private void createNewRanking(LocalDate date, CrewRankingData data, int rank) {
+        CrewRanking newRanking = CrewRanking.builder()
+                .date(date)
+                .crewId(data.getCrewId())
+                .rankPosition(rank)
+                .totalDistance(data.getTotalDistance())
+                .totalRunningTime(data.getTotalRunningTime())
+                .participantCount(data.getParticipantCount())
+                .build();
+        crewRankingRepository.save(newRanking);
+    }
+
+    private void updateExistingRanking(CrewRanking existing, CrewRankingData data, int rank) {
+        boolean needsUpdate = existing.getRankPosition() != rank ||
+                Math.abs(existing.getTotalDistance() - data.getTotalDistance()) > 0.01 ||
+                !existing.getTotalRunningTime().equals(data.getTotalRunningTime()) ||
+                !existing.getParticipantCount().equals(data.getParticipantCount());
+        
+        if (needsUpdate) {
+            existing.updateRankPosition(rank);
+            existing.updateTotalDistance(data.getTotalDistance());
+            existing.updateTotalRunningTime(data.getTotalRunningTime());
+            existing.updateParticipantCount(data.getParticipantCount());
+            crewRankingRepository.save(existing);
+        }
+    }
+
+    private void updateOrCreateCrewRanking(Long crewId, LocalDate date, CrewRecord newRecord) {
+        Optional<CrewRanking> existingRanking = crewRankingRepository.findByDateAndCrewId(date, crewId);
+        
+        if (existingRanking.isPresent()) {
+            existingRanking.get().addCrewRecord(newRecord.getDistance(), newRecord.getRunningTime());
+            crewRankingRepository.save(existingRanking.get());
+        } else {
+            createNewRanking(date, crewId, newRecord);
+        }
+    }
+
+    private void createNewRanking(LocalDate date, Long crewId, CrewRecord record) {
+        CrewRanking newRanking = CrewRanking.builder()
+                .date(date)
+                .crewId(crewId)
+                .rankPosition(1) // 임시 순위로 순위 지정 reorderRankPositions에서 추후 재정렬
+                .totalDistance(record.getDistance())
+                .totalRunningTime(record.getRunningTime())
+                .participantCount(1)
+                .build();
+        crewRankingRepository.save(newRanking);
+    }
+
+    private void reorderRankPositions(LocalDate date) {
+        List<CrewRanking> rankings = crewRankingRepository.findByDateOrderByTotalDistanceDesc(date);
+        
+        for (int i = 0; i < rankings.size(); i++) {
+            rankings.get(i).updateRankPosition(i + 1);
+        }
+        
+        crewRankingRepository.saveAll(rankings);
+    }
+
+    private Long getCrewIdFromRecord(CrewRecord record) {
+        return crewRunningRepository.findById(record.getCrewRunningId())
+                .map(CrewRunning::getCrewId)
+                .orElse(null);
+    }
+
+    private CrewRankingDTO.CrewRankInfo convertToRankInfo(CrewRanking crewRanking) {
+        Optional<Crew> crew = crewRepository.findById(crewRanking.getCrewId());
+        
+        return CrewRankingDTO.CrewRankInfo.builder()
+                .crewId(crewRanking.getCrewId())
+                .crewName(crew.map(Crew::getTitle).orElse("Unknown"))
+                .crewPhoto(crew.map(Crew::getPhoto).orElse(null))
+                .totalDistance(crewRanking.getTotalDistance())
+                .totalRunningTime(crewRanking.getTotalRunningTime())
+                .participantCount(crewRanking.getParticipantCount())
+                .rank(crewRanking.getRankPosition())
+                .build();
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewRunningService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewRunningService.java
@@ -1,0 +1,86 @@
+package com.runtracker.domain.crew.service;
+
+import com.runtracker.domain.course.entity.Course;
+import com.runtracker.domain.course.repository.CourseRepository;
+import com.runtracker.domain.crew.dto.CrewCourseRecommendationDTO;
+import com.runtracker.domain.crew.entity.Crew;
+import com.runtracker.domain.crew.exception.CrewNotFoundException;
+import com.runtracker.domain.crew.repository.CrewRepository;
+import com.runtracker.domain.record.repository.RecordRepository;
+import com.runtracker.global.security.CrewAuthorizationUtil;
+import com.runtracker.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CrewRunningService {
+
+    private final CrewRepository crewRepository;
+    private final CourseRepository courseRepository;
+    private final RecordRepository recordRepository;
+    private final CrewAuthorizationUtil authorizationUtil;
+
+    @Transactional(readOnly = true)
+    public List<CrewCourseRecommendationDTO.Response> getRecommendedCourses(
+            Long crewId, String region, Double minDistance, Double maxDistance, UserDetailsImpl userDetails) {
+
+        Crew crew = crewRepository.findById(crewId)
+                .orElseThrow(CrewNotFoundException::new);
+
+        authorizationUtil.validateCrewManagementPermission(userDetails, crewId);
+
+        CrewCourseRecommendationDTO.Request request = CrewCourseRecommendationDTO.Request.builder()
+                .region(region)
+                .minDistance(minDistance)
+                .maxDistance(maxDistance)
+                .build();
+
+        List<Course> courses = courseRepository.findAll();
+
+        return courses.stream()
+                .filter(course -> matchesRequest(course, request))
+                .sorted((c1, c2) -> Boolean.compare(isCrewMatchingCourse(c2, crew), isCrewMatchingCourse(c1, crew)))
+                .map(course -> mapToCourseRecommendation(course, crew))
+                .limit(20)
+                .toList();
+    }
+
+    private boolean matchesRequest(Course course, CrewCourseRecommendationDTO.Request request) {
+        if (request.getRegion() != null && course.getRegion() != null &&
+                !course.getRegion().contains(request.getRegion())) {
+            return false;
+        }
+
+        if (request.getMinDistance() != null && course.getDistance() < request.getMinDistance()) {
+            return false;
+        }
+
+        return request.getMaxDistance() == null || course.getDistance() <= request.getMaxDistance();
+    }
+
+    private CrewCourseRecommendationDTO.Response mapToCourseRecommendation(Course course, Crew crew) {
+        return CrewCourseRecommendationDTO.Response.builder()
+                .courseId(course.getId())
+                .name(course.getName())
+                .region(course.getRegion())
+                .distance(course.getDistance())
+                .difficulty(course.getDifficulty())
+                .startLat(course.getStartLat())
+                .startLng(course.getStartLng())
+                .photo(course.getPhoto())
+                .createdAt(course.getCreatedAt())
+                .build();
+    }
+
+    private boolean isCrewMatchingCourse(Course course, Crew crew) {
+        boolean regionMatch = crew.getRegion() != null && crew.getRegion().equals(course.getRegion());
+        boolean difficultyMatch = crew.getDifficulty() != null && crew.getDifficulty().equals(course.getDifficulty());
+
+        return regionMatch || difficultyMatch;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
@@ -8,8 +8,11 @@ import com.runtracker.domain.crew.dto.CrewManagementDTO;
 import com.runtracker.domain.crew.dto.CrewMemberUpdateDTO;
 import com.runtracker.domain.crew.dto.CrewUpdateDTO;
 import com.runtracker.domain.crew.dto.MemberProfileDTO;
+import com.runtracker.domain.crew.dto.CrewRecordDTO;
 import com.runtracker.domain.crew.entity.Crew;
 import com.runtracker.domain.crew.entity.CrewMember;
+import com.runtracker.domain.crew.entity.CrewRecord;
+import com.runtracker.domain.crew.entity.CrewRunning;
 import com.runtracker.domain.crew.enums.CrewMemberStatus;
 import com.runtracker.domain.crew.exception.AlreadyCrewMemberException;
 import com.runtracker.domain.crew.exception.AlreadyJoinedOtherCrewException;
@@ -29,6 +32,8 @@ import com.runtracker.domain.crew.exception.NoPendingApplicationException;
 import com.runtracker.domain.crew.exception.SameRoleUpdateException;
 import com.runtracker.domain.crew.repository.CrewRepository;
 import com.runtracker.domain.crew.repository.CrewMemberRepository;
+import com.runtracker.domain.crew.repository.CrewRecordRepository;
+import com.runtracker.domain.crew.repository.CrewRunningRepository;
 import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.entity.enums.MemberRole;
 import com.runtracker.domain.member.repository.MemberRepository;
@@ -48,6 +53,8 @@ public class CrewService {
 
     private final CrewRepository crewRepository;
     private final CrewMemberRepository crewMemberRepository;
+    private final CrewRecordRepository crewRecordRepository;
+    private final CrewRunningRepository crewRunningRepository;
     private final MemberRepository memberRepository;
     private final CrewAuthorizationUtil authorizationUtil;
     private final TokenBlacklistService tokenBlacklistService;
@@ -378,5 +385,34 @@ public class CrewService {
     
     private boolean isValidCrewRole(MemberRole role) {
         return role == MemberRole.CREW_MEMBER || role == MemberRole.CREW_MANAGER;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CrewRecordDTO> getCrewRecords(Long crewId, UserDetailsImpl userDetails) {
+        authorizationUtil.validateCrewMemberAccess(userDetails, crewId);
+
+        List<CrewRecord> crewRecords = crewRecordRepository.findByCrewRunningIdIn(
+                getCrewRunningIds(crewId));
+        
+        return crewRecords.stream()
+                .map(CrewRecordDTO::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CrewRecordDTO getCrewRecord(Long crewId, Long crewRunningId, UserDetailsImpl userDetails) {
+        authorizationUtil.validateCrewMemberAccess(userDetails, crewId);
+
+        CrewRecord crewRecord = crewRecordRepository.findByCrewRunningId(crewRunningId)
+                .orElseThrow(() -> new RuntimeException("크루 기록을 찾을 수 없습니다."));
+        
+        return CrewRecordDTO.from(crewRecord);
+    }
+
+    private List<Long> getCrewRunningIds(Long crewId) {
+        return crewRunningRepository.findByCrewIdOrderByCreatedAtDesc(crewId)
+                .stream()
+                .map(CrewRunning::getId)
+                .toList();
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/crew/service/CrewService.java
@@ -26,7 +26,6 @@ import com.runtracker.domain.crew.exception.CrewNotFoundException;
 import com.runtracker.domain.crew.exception.InvalidCrewRoleException;
 import com.runtracker.domain.crew.exception.MemberNotFoundException;
 import com.runtracker.domain.crew.exception.NoPendingApplicationException;
-import com.runtracker.domain.crew.exception.NotCrewLeaderException;
 import com.runtracker.domain.crew.exception.SameRoleUpdateException;
 import com.runtracker.domain.crew.repository.CrewRepository;
 import com.runtracker.domain.crew.repository.CrewMemberRepository;
@@ -380,5 +379,4 @@ public class CrewService {
     private boolean isValidCrewRole(MemberRole role) {
         return role == MemberRole.CREW_MEMBER || role == MemberRole.CREW_MANAGER;
     }
-
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/controller/RecordController.java
@@ -22,20 +22,6 @@ public class RecordController {
     
     private final RecordService recordService;
 
-    @PostMapping("/save")
-    public ApiResponse<Void> saveRunningRecord(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody RunningRecordDTO createDTO) {
-        try {
-            recordService.saveRunningRecord(userDetails.getMemberId(), createDTO);
-            return ApiResponse.ok();
-        } catch (CustomException e) {
-            return ApiResponse.error(e.getResponseCode());
-        } catch (Exception e) {
-            return ApiResponse.error(CommonResponseCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
     @GetMapping("/date")
     public ApiResponse<List<RunningRecordDTO>> getRunningRecordsByDateRange(
             @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/runtracker/src/main/java/com/runtracker/domain/record/dto/RunningRecordDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/dto/RunningRecordDTO.java
@@ -6,11 +6,13 @@ import com.runtracker.global.code.DateConstants;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class RunningRecordDTO {

--- a/runtracker/src/main/java/com/runtracker/domain/record/dto/RunningRecordDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/dto/RunningRecordDTO.java
@@ -18,9 +18,15 @@ public class RunningRecordDTO {
     private Long id;
     private Long courseId;
     
+    private Integer runningTime;
+    
     @DateTimeFormat(pattern = DateConstants.DATETIME_PATTERN)
     @JsonFormat(pattern = DateConstants.DATETIME_PATTERN)
-    private LocalDateTime runningTime;
+    private LocalDateTime startedAt;
+    
+    @DateTimeFormat(pattern = DateConstants.DATETIME_PATTERN)
+    @JsonFormat(pattern = DateConstants.DATETIME_PATTERN)
+    private LocalDateTime finishedAt;
     
     private Double distance;
     private Integer walk;
@@ -31,6 +37,8 @@ public class RunningRecordDTO {
                 runningRecord.getId(),
                 runningRecord.getCourseId(),
                 runningRecord.getRunningTime(),
+                runningRecord.getStartedAt(),
+                runningRecord.getFinishedAt(),
                 runningRecord.getDistance(),
                 runningRecord.getWalk(),
                 runningRecord.getCalorie()

--- a/runtracker/src/main/java/com/runtracker/domain/record/entity/RunningRecord.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/entity/RunningRecord.java
@@ -4,9 +4,7 @@ import com.runtracker.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Duration;
 
 @Entity
 @Table(name = "running_record")
@@ -46,4 +44,12 @@ public class RunningRecord extends BaseEntity {
 
     @Column(name = "calorie")
     private Integer calorie;
+    
+    public void updateFinishRunning(Integer runningTime, LocalDateTime finishedAt, Double distance, Integer walk, Integer calorie) {
+        this.runningTime = runningTime;
+        this.finishedAt = finishedAt;
+        this.distance = distance;
+        this.walk = walk;
+        this.calorie = calorie;
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/enums/RecordErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/enums/RecordErrorCode.java
@@ -12,7 +12,8 @@ public enum RecordErrorCode implements ResponseCode {
     INVALID_DATE_RANGE("RC002", "Start date must be before or equal to end date"),
     DATE_RANGE_TOO_LARGE("RC003", "Date range cannot exceed 365 days"),
     DATE_PARAMETER_REQUIRED("RC004", "Date parameters are required"),
-    RECORD_NOT_FOUND("RC005", "Running record not found");
+    RECORD_NOT_FOUND("RC005", "Running record not found"),
+    UNAUTHORIZED_RECORD_ACCESS("RC006", "Unauthorized access to running record");
     
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/record/exception/UnauthorizedRecordAccessException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/exception/UnauthorizedRecordAccessException.java
@@ -1,0 +1,11 @@
+package com.runtracker.domain.record.exception;
+
+import com.runtracker.domain.record.enums.RecordErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class UnauthorizedRecordAccessException extends CustomException {
+    
+    public UnauthorizedRecordAccessException(String message) {
+        super(RecordErrorCode.UNAUTHORIZED_RECORD_ACCESS, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
@@ -19,4 +19,6 @@ public interface RecordRepository extends JpaRepository<RunningRecord, Long> {
     
     @Query("SELECT r FROM RunningRecord r WHERE r.memberId = :memberId AND r.courseId = :courseId ORDER BY r.runningTime DESC")
     List<RunningRecord> findByMemberIdAndCourseId(@Param("memberId") Long memberId, @Param("courseId") Long courseId);
+
+    List<RunningRecord> findByCrewRunningId(Long crewRunningId);
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RecordRepository extends JpaRepository<RunningRecord, Long> {
@@ -16,9 +17,8 @@ public interface RecordRepository extends JpaRepository<RunningRecord, Long> {
     
     @Query("SELECT r FROM RunningRecord r WHERE r.memberId = :memberId AND DATE(r.runningTime) BETWEEN :startDate AND :endDate ORDER BY r.runningTime DESC")
     List<RunningRecord> findByMemberIdAndRunningTimeBetween(@Param("memberId") Long memberId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
-    
-    @Query("SELECT r FROM RunningRecord r WHERE r.memberId = :memberId AND r.courseId = :courseId ORDER BY r.runningTime DESC")
-    List<RunningRecord> findByMemberIdAndCourseId(@Param("memberId") Long memberId, @Param("courseId") Long courseId);
 
     List<RunningRecord> findByCrewRunningId(Long crewRunningId);
+    
+    List<RunningRecord> findAllByMemberIdAndFinishedAtIsNull(Long memberId);
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/service/RecordService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/service/RecordService.java
@@ -46,6 +46,8 @@ public class RecordService {
                 .memberId(memberId)
                 .courseId(createDTO.getCourseId())
                 .runningTime(createDTO.getRunningTime())
+                .startedAt(createDTO.getStartedAt())
+                .finishedAt(createDTO.getFinishedAt())
                 .distance(createDTO.getDistance())
                 .walk(createDTO.getWalk())
                 .calorie(createDTO.getCalorie())

--- a/runtracker/src/main/java/com/runtracker/domain/record/service/RecordService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/service/RecordService.java
@@ -1,19 +1,12 @@
 package com.runtracker.domain.record.service;
 
-import com.runtracker.domain.member.exception.MemberNotFoundException;
 import com.runtracker.domain.record.dto.RunningRecordDTO;
 import com.runtracker.domain.record.entity.RunningRecord;
-import com.runtracker.domain.record.exception.CourseNotFoundForRecordException;
 import com.runtracker.domain.record.exception.InvalidDateRangeException;
 import com.runtracker.domain.record.exception.DateRangeTooLargeException;
 import com.runtracker.domain.record.exception.DateParameterRequiredException;
 import com.runtracker.domain.record.exception.RecordNotFoundException;
 import com.runtracker.domain.record.repository.RecordRepository;
-import com.runtracker.domain.course.repository.CourseRepository;
-import com.runtracker.domain.course.entity.Course;
-import com.runtracker.domain.member.entity.Member;
-import com.runtracker.domain.member.repository.MemberRepository;
-import com.runtracker.domain.member.service.TempCalcService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,39 +23,6 @@ import java.util.stream.Collectors;
 public class RecordService {
     
     private final RecordRepository recordRepository;
-    private final CourseRepository courseRepository;
-    private final MemberRepository memberRepository;
-    private final TempCalcService temperatureCalculationService;
-
-    @Transactional
-    public void saveRunningRecord(Long memberId, RunningRecordDTO createDTO) {
-        Course course = courseRepository.findById(createDTO.getCourseId())
-                .orElseThrow(() -> new CourseNotFoundForRecordException("Course not found with id: " + createDTO.getCourseId()));
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException("Member not found with id: " + memberId));
-
-        RunningRecord runningRecord = RunningRecord.builder()
-                .memberId(memberId)
-                .courseId(createDTO.getCourseId())
-                .runningTime(createDTO.getRunningTime())
-                .startedAt(createDTO.getStartedAt())
-                .finishedAt(createDTO.getFinishedAt())
-                .distance(createDTO.getDistance())
-                .walk(createDTO.getWalk())
-                .calorie(createDTO.getCalorie())
-                .build();
-        
-        recordRepository.save(runningRecord);
-
-        double newTemperature = temperatureCalculationService.calculateNewTemperature(
-                member.getTemperature(), createDTO.getDistance(), course.getDistance());
-
-        double roundedTemperature = Math.round(newTemperature * 10.0) / 10.0;
-        
-        member.updateTemperature(roundedTemperature);
-        memberRepository.save(member);
-    }
 
     @Transactional(readOnly = true)
     public List<RunningRecordDTO> getAllRunningRecords(Long memberId) {

--- a/runtracker/src/main/java/com/runtracker/global/exception/GlobalExceptionHandler.java
+++ b/runtracker/src/main/java/com/runtracker/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 
 @Slf4j
@@ -48,6 +49,14 @@ public class GlobalExceptionHandler {
     public ApiResponse<Object> handleMissingParameter(MissingServletRequestParameterException e) {
         log.warn("Missing required parameter: {}", e.getMessage());
         String message = "Missing required parameter : " + e.getParameterName();
+        return ApiResponse.error(CommonResponseCode.NOT_VALID_ERROR, message);
+    }
+    
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("Request body missing or malformed: {}", e.getMessage());
+        String message = "Required request body is missing or malformed";
         return ApiResponse.error(CommonResponseCode.NOT_VALID_ERROR, message);
     }
     

--- a/runtracker/src/main/java/com/runtracker/global/security/CrewAuthorizationUtil.java
+++ b/runtracker/src/main/java/com/runtracker/global/security/CrewAuthorizationUtil.java
@@ -1,9 +1,8 @@
 package com.runtracker.global.security;
 
 import com.runtracker.domain.crew.exception.NotCrewLeaderException;
+import com.runtracker.domain.crew.exception.UnauthorizedCrewAccessException;
 import com.runtracker.domain.member.entity.enums.MemberRole;
-import com.runtracker.domain.schedule.enums.ScheduleErrorCode;
-import com.runtracker.global.exception.CustomException;
 import com.runtracker.global.security.dto.CrewMembership;
 import org.springframework.stereotype.Component;
 
@@ -56,11 +55,11 @@ public class CrewAuthorizationUtil {
         CrewMembership membership = userDetails.getCrewMembership();
         
         if (membership == null) {
-            throw new CustomException(ScheduleErrorCode.UNAUTHORIZED_SCHEDULE_ACCESS);
+            throw new UnauthorizedCrewAccessException();
         }
         
         if (!membership.getCrewId().equals(crewId)) {
-            throw new CustomException(ScheduleErrorCode.UNAUTHORIZED_SCHEDULE_ACCESS);
+            throw new UnauthorizedCrewAccessException();
         }
     }
 }

--- a/runtracker/src/test/java/com/runtracker/domain/course/controller/CourseControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/course/controller/CourseControllerTest.java
@@ -313,6 +313,45 @@ class CourseControllerTest extends RunTrackerDocumentApiTester {
     }
 
     @Test
+    void startRunningCourseTest() throws Exception {
+        // given
+        doNothing().when(courseService).startRunningCourse(anyLong(), anyLong());
+        given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
+        given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
+
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(1L)
+                .socialId("kakao_123")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("1")).willReturn(mockUserDetails);
+
+        // when
+        this.mockMvc.perform(post("/api/courses/{courseId}/running", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("course-start-running",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("courses")
+                                        .description("기존 코스로 러닝 시작")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("courseId").description("시작할 코스 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
     void finishRunningTest() throws Exception {
         // given
         doNothing().when(courseService).finishRunning(anyLong(), any(FinishRunning.class));

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -1389,4 +1389,52 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                         )
                 ));
     }
+
+    @Test
+    void finishCrewRunning() throws Exception {
+        // given
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(400L)
+                .socialId("kakao_400")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("400")).willReturn(mockUserDetails);
+
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("distance", 5000.0);
+        request.put("walk", 100);
+        request.put("calorie", 350);
+
+        // when
+        this.mockMvc.perform(post("/api/crew/{crewId}/running/{crewRunningId}/finish", 1L, 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("crew-running-finish",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew-running")
+                                        .description("크루 런닝 개별 완료")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("crewId").description("크루 ID"),
+                                                parameterWithName("crewRunningId").description("크루 런닝 방 ID")
+                                        )
+                                        .requestFields(
+                                                fieldWithPath("distance").type(JsonFieldType.NUMBER).description("거리(미터)"),
+                                                fieldWithPath("walk").type(JsonFieldType.NUMBER).description("걸음 수"),
+                                                fieldWithPath("calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
 }

--- a/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/crew/controller/CrewControllerTest.java
@@ -15,6 +15,7 @@ import com.runtracker.domain.course.dto.CourseDetailDTO;
 import com.runtracker.domain.course.dto.CourseDTO;
 import com.runtracker.domain.course.entity.vo.Coordinate;
 import com.runtracker.domain.crew.dto.MemberProfileDTO;
+import com.runtracker.domain.crew.dto.CrewRecordDTO;
 import com.runtracker.domain.crew.dto.CrewRunningDTO;
 import com.runtracker.domain.crew.enums.CrewMemberStatus;
 import com.runtracker.domain.crew.enums.CrewRunningStatus;
@@ -1432,6 +1433,143 @@ class CrewControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
                                                 fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
                                                 fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void getCrewRecords() throws Exception {
+        // given
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(400L)
+                .socialId("kakao_400")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("400")).willReturn(mockUserDetails);
+
+        List<CrewRecordDTO> mockRecords = List.of(
+                new CrewRecordDTO(
+                        1L,
+                        1L,
+                        1L,
+                        1800,
+                        LocalDateTime.of(2025, 8, 16, 7, 0, 0),
+                        LocalDateTime.of(2025, 8, 16, 7, 30, 0),
+                        5000.0,
+                        7500.0,
+                        350.0,
+                        3
+                ),
+                new CrewRecordDTO(
+                        2L,
+                        2L,
+                        2L,
+                        2100,
+                        LocalDateTime.of(2025, 8, 15, 6, 0, 0),
+                        LocalDateTime.of(2025, 8, 15, 6, 35, 0),
+                        3000.0,
+                        4500.0,
+                        250.0,
+                        2
+                )
+        );
+
+        given(crewService.getCrewRecords(anyLong(), any(UserDetailsImpl.class))).willReturn(mockRecords);
+
+        // when
+        this.mockMvc.perform(get("/api/crew/{crewId}/records", 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-records-list",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew-records")
+                                        .description("크루 기록 전체 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("crewId").description("크루 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.ARRAY).description("크루 기록 목록"),
+                                                fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("크루 기록 ID"),
+                                                fieldWithPath("body[].crewRunningId").type(JsonFieldType.NUMBER).description("크루 런닝 ID"),
+                                                fieldWithPath("body[].courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
+                                                fieldWithPath("body[].runningTime").type(JsonFieldType.NUMBER).description("평균 런닝 시간 (초 단위)"),
+                                                fieldWithPath("body[].startedAt").type(JsonFieldType.STRING).description("크루 런닝 시작 시간"),
+                                                fieldWithPath("body[].finishedAt").type(JsonFieldType.STRING).description("크루 런닝 완료 시간"),
+                                                fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("평균 거리 (미터)"),
+                                                fieldWithPath("body[].walk").type(JsonFieldType.NUMBER).description("평균 걸음 수"),
+                                                fieldWithPath("body[].calorie").type(JsonFieldType.NUMBER).description("평균 소모 칼로리"),
+                                                fieldWithPath("body[].participantCount").type(JsonFieldType.NUMBER).description("참여자 수")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void getCrewRecord() throws Exception {
+        // given
+        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
+                .memberId(400L)
+                .socialId("kakao_400")
+                .roles(List.of(MemberRole.USER))
+                .build();
+        given(userDetailsService.loadUserByUsername("400")).willReturn(mockUserDetails);
+
+        CrewRecordDTO mockRecord = new CrewRecordDTO(
+                1L,
+                1L,
+                1L,
+                1800,
+                LocalDateTime.of(2025, 8, 16, 7, 0, 0),
+                LocalDateTime.of(2025, 8, 16, 7, 30, 0),
+                5000.0,
+                7500.0,
+                350.0,
+                3
+        );
+
+        given(crewService.getCrewRecord(anyLong(), anyLong(), any(UserDetailsImpl.class))).willReturn(mockRecord);
+
+        // when
+        this.mockMvc.perform(get("/api/crew/{crewId}/records/{crewRunningId}", 1L, 1L)
+                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("crew-record-detail",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("crew-records")
+                                        .description("크루 기록 상세 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("액세스 토큰")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("crewId").description("크루 ID"),
+                                                parameterWithName("crewRunningId").description("크루 런닝 ID")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.OBJECT).description("크루 기록 상세"),
+                                                fieldWithPath("body.id").type(JsonFieldType.NUMBER).description("크루 기록 ID"),
+                                                fieldWithPath("body.crewRunningId").type(JsonFieldType.NUMBER).description("크루 런닝 ID"),
+                                                fieldWithPath("body.courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
+                                                fieldWithPath("body.runningTime").type(JsonFieldType.NUMBER).description("평균 런닝 시간 (초 단위)"),
+                                                fieldWithPath("body.startedAt").type(JsonFieldType.STRING).description("크루 런닝 시작 시간"),
+                                                fieldWithPath("body.finishedAt").type(JsonFieldType.STRING).description("크루 런닝 완료 시간"),
+                                                fieldWithPath("body.distance").type(JsonFieldType.NUMBER).description("평균 거리 (미터)"),
+                                                fieldWithPath("body.walk").type(JsonFieldType.NUMBER).description("평균 걸음 수"),
+                                                fieldWithPath("body.calorie").type(JsonFieldType.NUMBER).description("평균 소모 칼로리"),
+                                                fieldWithPath("body.participantCount").type(JsonFieldType.NUMBER).description("참여자 수")
                                         )
                                         .build()
                         )

--- a/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
@@ -42,7 +42,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
         // given
         Map<String, Object> createRequest = new LinkedHashMap<>();
         createRequest.put("courseId", 1L);
-        createRequest.put("runningTime", "2025-08-16 07:30:00");
+        createRequest.put("runningTime", 2400);
+        createRequest.put("startedAt", "2025-08-16 07:30:00");
+        createRequest.put("finishedAt", "2025-08-16 08:10:00");
         createRequest.put("distance", 5000.0);
         createRequest.put("walk", 100);
         createRequest.put("calorie", 350);
@@ -74,7 +76,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                                         )
                                         .requestFields(
                                                 fieldWithPath("courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("runningTime").type(JsonFieldType.STRING).description("러닝 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("runningTime").type(JsonFieldType.NUMBER).description("러닝 시간 (초 단위)"),
+                                                fieldWithPath("startedAt").type(JsonFieldType.STRING).description("러닝 시작 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("finishedAt").type(JsonFieldType.STRING).description("러닝 종료 시간 (yyyy-MM-dd HH:mm:ss)"),
                                                 fieldWithPath("distance").type(JsonFieldType.NUMBER).description("러닝 거리 (미터)"),
                                                 fieldWithPath("walk").type(JsonFieldType.NUMBER).description("걸음 수"),
                                                 fieldWithPath("calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")
@@ -96,7 +100,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         1L,
                         1L,
+                        1800,
                         LocalDateTime.of(2025, 8, 15, 6, 0, 0),
+                        LocalDateTime.of(2025, 8, 15, 6, 30, 0),
                         3000.0,
                         4500,
                         250
@@ -104,7 +110,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         2L,
                         2L,
+                        2400,
                         LocalDateTime.of(2025, 8, 16, 7, 30, 0),
+                        LocalDateTime.of(2025, 8, 16, 8, 10, 0),
                         5000.0,
                         7200,
                         400
@@ -147,7 +155,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("body").type(JsonFieldType.ARRAY).description("러닝 기록 목록"),
                                                 fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("러닝 기록 ID"),
                                                 fieldWithPath("body[].courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("body[].runningTime").type(JsonFieldType.STRING).description("러닝 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].runningTime").type(JsonFieldType.NUMBER).description("러닝 시간 (초 단위)"),
+                                                fieldWithPath("body[].startedAt").type(JsonFieldType.STRING).description("러닝 시작 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].finishedAt").type(JsonFieldType.STRING).description("러닝 종료 시간 (yyyy-MM-dd HH:mm:ss)"),
                                                 fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("러닝 거리 (미터)"),
                                                 fieldWithPath("body[].walk").type(JsonFieldType.NUMBER).description("걸음 수"),
                                                 fieldWithPath("body[].calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")
@@ -164,7 +174,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         1L,
                         1L,
+                        2100,
                         LocalDateTime.of(2025, 8, 11, 8, 0, 0),
+                        LocalDateTime.of(2025, 8, 11, 8, 35, 0),
                         4000.0,
                         6000,
                         320
@@ -172,7 +184,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         2L,
                         2L,
+                        3000,
                         LocalDateTime.of(2025, 8, 13, 18, 30, 0),
+                        LocalDateTime.of(2025, 8, 13, 19, 20, 0),
                         6000.0,
                         8500,
                         480
@@ -213,7 +227,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("body").type(JsonFieldType.ARRAY).description("러닝 기록 목록"),
                                                 fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("러닝 기록 ID"),
                                                 fieldWithPath("body[].courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("body[].runningTime").type(JsonFieldType.STRING).description("러닝 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].runningTime").type(JsonFieldType.NUMBER).description("러닝 시간 (초 단위)"),
+                                                fieldWithPath("body[].startedAt").type(JsonFieldType.STRING).description("러닝 시작 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].finishedAt").type(JsonFieldType.STRING).description("러닝 종료 시간 (yyyy-MM-dd HH:mm:ss)"),
                                                 fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("러닝 거리 (미터)"),
                                                 fieldWithPath("body[].walk").type(JsonFieldType.NUMBER).description("걸음 수"),
                                                 fieldWithPath("body[].calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")
@@ -230,7 +246,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         1L,
                         1L,
+                        3600,
                         LocalDateTime.of(2025, 8, 5, 7, 0, 0),
+                        LocalDateTime.of(2025, 8, 5, 8, 0, 0),
                         8000.0,
                         12000,
                         650
@@ -238,7 +256,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         2L,
                         2L,
+                        2700,
                         LocalDateTime.of(2025, 8, 25, 19, 0, 0),
+                        LocalDateTime.of(2025, 8, 25, 19, 45, 0),
                         5500.0,
                         8200,
                         420
@@ -279,7 +299,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("body").type(JsonFieldType.ARRAY).description("러닝 기록 목록"),
                                                 fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("러닝 기록 ID"),
                                                 fieldWithPath("body[].courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("body[].runningTime").type(JsonFieldType.STRING).description("러닝 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].runningTime").type(JsonFieldType.NUMBER).description("러닝 시간 (초 단위)"),
+                                                fieldWithPath("body[].startedAt").type(JsonFieldType.STRING).description("러닝 시작 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].finishedAt").type(JsonFieldType.STRING).description("러닝 종료 시간 (yyyy-MM-dd HH:mm:ss)"),
                                                 fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("러닝 거리 (미터)"),
                                                 fieldWithPath("body[].walk").type(JsonFieldType.NUMBER).description("걸음 수"),
                                                 fieldWithPath("body[].calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")
@@ -295,7 +317,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
         RunningRecordDTO mockRecord = new RunningRecordDTO(
                 1L,
                 1L,
+                2400,
                 LocalDateTime.of(2025, 8, 16, 7, 30, 0),
+                LocalDateTime.of(2025, 8, 16, 8, 10, 0),
                 5000.0,
                 7200,
                 400
@@ -334,7 +358,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("body").type(JsonFieldType.OBJECT).description("러닝 기록 상세"),
                                                 fieldWithPath("body.id").type(JsonFieldType.NUMBER).description("러닝 기록 ID"),
                                                 fieldWithPath("body.courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("body.runningTime").type(JsonFieldType.STRING).description("러닝 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body.runningTime").type(JsonFieldType.NUMBER).description("러닝 시간 (초 단위)"),
+                                                fieldWithPath("body.startedAt").type(JsonFieldType.STRING).description("러닝 시작 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body.finishedAt").type(JsonFieldType.STRING).description("러닝 종료 시간 (yyyy-MM-dd HH:mm:ss)"),
                                                 fieldWithPath("body.distance").type(JsonFieldType.NUMBER).description("러닝 거리 (미터)"),
                                                 fieldWithPath("body.walk").type(JsonFieldType.NUMBER).description("걸음 수"),
                                                 fieldWithPath("body.calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")
@@ -351,7 +377,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         1L,
                         1L,
+                        2400,
                         LocalDateTime.of(2025, 8, 16, 7, 30, 0),
+                        LocalDateTime.of(2025, 8, 16, 8, 10, 0),
                         5000.0,
                         7200,
                         400
@@ -359,7 +387,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                 new RunningRecordDTO(
                         2L,
                         2L,
+                        1800,
                         LocalDateTime.of(2025, 8, 15, 6, 0, 0),
+                        LocalDateTime.of(2025, 8, 15, 6, 30, 0),
                         3000.0,
                         4500,
                         250
@@ -396,7 +426,9 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("body").type(JsonFieldType.ARRAY).description("러닝 기록 목록"),
                                                 fieldWithPath("body[].id").type(JsonFieldType.NUMBER).description("러닝 기록 ID"),
                                                 fieldWithPath("body[].courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("body[].runningTime").type(JsonFieldType.STRING).description("러닝 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].runningTime").type(JsonFieldType.NUMBER).description("러닝 시간 (초 단위)"),
+                                                fieldWithPath("body[].startedAt").type(JsonFieldType.STRING).description("러닝 시작 시간 (yyyy-MM-dd HH:mm:ss)"),
+                                                fieldWithPath("body[].finishedAt").type(JsonFieldType.STRING).description("러닝 종료 시간 (yyyy-MM-dd HH:mm:ss)"),
                                                 fieldWithPath("body[].distance").type(JsonFieldType.NUMBER).description("러닝 거리 (미터)"),
                                                 fieldWithPath("body[].walk").type(JsonFieldType.NUMBER).description("걸음 수"),
                                                 fieldWithPath("body[].calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")

--- a/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/record/controller/RecordControllerTest.java
@@ -1,8 +1,6 @@
 package com.runtracker.domain.record.controller;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.runtracker.RunTrackerDocumentApiTester;
 import com.runtracker.domain.record.dto.RunningRecordDTO;
 import com.runtracker.domain.record.service.RecordService;
@@ -13,19 +11,15 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -34,64 +28,6 @@ class RecordControllerTest extends RunTrackerDocumentApiTester {
 
     @MockitoBean
     private RecordService recordService;
-
-    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-
-    @Test
-    void saveRunningRecordTest() throws Exception {
-        // given
-        Map<String, Object> createRequest = new LinkedHashMap<>();
-        createRequest.put("courseId", 1L);
-        createRequest.put("runningTime", 2400);
-        createRequest.put("startedAt", "2025-08-16 07:30:00");
-        createRequest.put("finishedAt", "2025-08-16 08:10:00");
-        createRequest.put("distance", 5000.0);
-        createRequest.put("walk", 100);
-        createRequest.put("calorie", 350);
-
-        doNothing().when(recordService).saveRunningRecord(anyLong(), any(RunningRecordDTO.class));
-        given(jwtUtil.getMemberIdFromToken(anyString())).willReturn(1L);
-        given(jwtUtil.getSocialIdFromToken(anyString())).willReturn("kakao_123");
-
-        UserDetailsImpl mockUserDetails = UserDetailsImpl.builder()
-                .memberId(1L)
-                .socialId("kakao_123")
-                .roles(List.of(MemberRole.USER))
-                .build();
-        given(userDetailsService.loadUserByUsername("1")).willReturn(mockUserDetails);
-
-        // when
-        this.mockMvc.perform(post("/api/records/save")
-                        .header(AUTH_HEADER, TEST_ACCESS_TOKEN)
-                        .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(createRequest)))
-                .andExpect(status().isOk())
-                .andDo(document("record-save-running-record",
-                        resource(
-                                ResourceSnippetParameters.builder()
-                                        .tag("records")
-                                        .description("러닝 기록 저장")
-                                        .requestHeaders(
-                                                headerWithName("Authorization").description("엑세스 토큰")
-                                        )
-                                        .requestFields(
-                                                fieldWithPath("courseId").type(JsonFieldType.NUMBER).description("코스 ID"),
-                                                fieldWithPath("runningTime").type(JsonFieldType.NUMBER).description("러닝 시간 (초 단위)"),
-                                                fieldWithPath("startedAt").type(JsonFieldType.STRING).description("러닝 시작 시간 (yyyy-MM-dd HH:mm:ss)"),
-                                                fieldWithPath("finishedAt").type(JsonFieldType.STRING).description("러닝 종료 시간 (yyyy-MM-dd HH:mm:ss)"),
-                                                fieldWithPath("distance").type(JsonFieldType.NUMBER).description("러닝 거리 (미터)"),
-                                                fieldWithPath("walk").type(JsonFieldType.NUMBER).description("걸음 수"),
-                                                fieldWithPath("calorie").type(JsonFieldType.NUMBER).description("소모 칼로리")
-                                        )
-                                        .responseFields(
-                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
-                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
-                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
-                                        )
-                                        .build()
-                        )
-                ));
-    }
 
     @Test
     void getRunningRecordsByDateRangeTest() throws Exception {


### PR DESCRIPTION
## 주요 기능

### 1. 크루 런닝 시스템

#### 런닝 방 관리
- 런닝 방 생성: 크루장/매니저가 런닝 세션을 개설
- 참여/나가기: 크루원들이 자유롭게 런닝 방 참여 및 탈퇴
- 방 삭제: 크루장/매니저 권한으로 런닝 방 삭제
- 실시간 조회: 진행중인 런닝 방 목록과 상세 정보 실시간 확인

#### 런닝 코스
- 기존 코스 선택: 저장된 코스를 선택하여 런닝 시작
- 자유 런닝: 현재 위치에서 즉석으로 코스를 생성하여 런닝
- 개별 완료: 각자의 페이스로 런닝하고 개별적으로 완료 처리

### 2. 크루 랭킹 시스템

#### 크루 간 랭킹
- 전체 크루 순위: 모든 크루들의 총 누적 거리 기준 랭킹
- 실시간 업데이트: 런닝 완료 시 자동 랭킹 갱신
- 상세 통계: 총 거리, 런닝 시간, 참여자 수 등 종합적인 지표

#### 크루 내 멤버 랭킹
- 개별 성과 추적: 크루 내에서 각 멤버의 개인 성과 랭킹
- 누적 기록 기반: 오늘 날짜까지의 모든 런닝 활동 누적 계산
- 평균 지표 제공: 평균 거리, 평균 시간 등 성과 분석 지표

## API 명세서

### 크루 런닝 API (9개)
| Method | Endpoint                                                     | 설명            | 권한      |
|--------|--------------------------------------------------------------|---------------|---------|
| POST   | /api/crew/{crewId}/running/create                            | 크루 런닝 방 생성    | 크루장/매니저 |
| GET    | /api/crew/{crewId}/running/list                              | 크루 런닝 방 목록 조회 | 크루원     |
| DELETE | /api/crew/{crewId}/running/{crewRunningId}                   | 크루 런닝 방 삭제    | 크루장/매니저 |
| GET    | /api/crew/{crewId}/running/list/{crewRunningId}              | 크루 런닝 방 상세 조회 | 크루원     |
| POST   | /api/crew/{crewId}/running/{crewRunningId}/join              | 크루 런닝 방 참여    | 크루원     |
| POST   | /api/crew/{crewId}/running/{crewRunningId}/leave             | 크루 런닝 방 나가기   | 크루원     |
| POST   | /api/crew/{crewId}/running/{crewRunningId}/course/{courseId} | 기존 코스로 런닝 시작  | 참여자     |
| POST   | /api/crew/{crewId}/running/{crewRunningId}/free-running      | 자유 런닝 시작      | 참여자     |
| POST   | /api/crew/{crewId}/running/{crewRunningId}/finish            | 개별 런닝 완료      | 참여자     |

### 크루 랭킹 API (4개)
| Method | Endpoint                                      | 설명              | 권한      |
|--------|-----------------------------------------------|-----------------|---------|
| GET    | /api/crew/ranking/list                        | 크루 랭킹 조회        | 전체      |
| POST   | /api/crew/ranking/recalculate                 | 크루 랭킹 수동 재계산    | 관리자     |
| GET    | /api/crew/{crewId}/member-ranking             | 크루 멤버 랭킹 조회     | 크루원     |
| POST   | /api/crew/{crewId}/member-ranking/recalculate | 크루 멤버 랭킹 수동 재계산 | 크루장/매니저 |

## 데이터 플로우

### 런닝 세션 플로우
1. 크루장/매니저가 런닝 방 생성
  ↓
2. 크루원들이 런닝 방 참여
  ↓
3. 코스 선택 (기존 코스 or 자유 런닝)
  ↓
4. 런닝 시작 
  ↓
5. 개별 완료 처리 → 기록 저장
  ↓
6. 자동 랭킹 업데이트

### 랭킹 계산 플로우
런닝 완료
  ↓
개별 기록 저장 (RunningRecord)
  ↓
크루 기록 집계 (CrewRecord)
  ↓
크루 랭킹 업데이트 (CrewRanking)
  ↓
크루 멤버 랭킹 업데이트 (CrewMemberRanking)
  ↓
실시간 랭킹 조회 가능

## 데이터 무결성
- 트랜잭션 보장: 모든 데이터 변경 작업에 트랜잭션 적용
- 권한 체크: 각 API별로 적절한 권한 검증
- 상태 관리: 런닝 상태와 참여자 상태의 일관성 유지

## 테스트 커버리지
- 통합 테스트: 모든 API 엔드포인트에 대한 MockMvc 테스트 (총 13개 API)
- 비즈니스 로직 테스트: 랭킹 계산, 상태 전환 등 핵심 로직 검증
- Spring REST Docs: 자동 API 문서 생성으로 문서 동기화 보장

## 추가적으로
- 이 pr 머지되고 추가할 커밋들이 있어서 여기에 추가하겠음
-  커밋 내용
   - Fix: [Course] 기록저장 api 삭제 및 러닝 종료 api 추가
   - Feat: [Course] 기존 코스로 런닝 api