### PR TITLE
Feat: [Member] 프로필 설정 구현

### DIFF
--- a/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.domain.member.service.MemberService;
 import com.runtracker.domain.member.service.AuthService;
 import com.runtracker.domain.member.entity.Member;
+import com.runtracker.domain.member.dto.MemberUpdateDTO;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -60,5 +61,12 @@ public class MemberController {
     public ApiResponse<Member> getProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         Member member = memberService.getMemberById(userDetails.getMemberId());
         return ApiResponse.ok(member);
+    }
+
+    @PatchMapping("/update")
+    public ApiResponse<Void> updateProfile(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @Valid @RequestBody MemberUpdateDTO.Request request) {
+        memberService.updateProfile(userDetails.getMemberId(), request);
+        return ApiResponse.ok();
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.runtracker.domain.member.service.AuthService;
 import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.dto.MemberUpdateDTO;
 import com.runtracker.domain.member.dto.NotificationSettingDTO;
+import com.runtracker.domain.member.dto.RunningBackupDTO;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -76,5 +77,23 @@ public class MemberController {
                                                        @Valid @RequestBody NotificationSettingDTO.Request request) {
         memberService.updateNotificationSetting(userDetails.getMemberId(), request);
         return ApiResponse.ok();
+    }
+
+    @PostMapping("/backup")
+    public ApiResponse<Void> createOrUpdateBackup(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        memberService.createBackup(userDetails.getMemberId());
+        return ApiResponse.ok();
+    }
+
+    @PostMapping("/restore")
+    public ApiResponse<Void> restoreRunningRecords(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        memberService.restoreRunningRecords(userDetails.getMemberId());
+        return ApiResponse.ok();
+    }
+
+    @GetMapping("/backup/info")
+    public ApiResponse<RunningBackupDTO.BackupInfo> getBackupInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        RunningBackupDTO.BackupInfo backupInfo = memberService.getBackupInfo(userDetails.getMemberId());
+        return ApiResponse.ok(backupInfo);
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.runtracker.domain.member.controller;
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.domain.member.service.MemberService;
 import com.runtracker.domain.member.service.AuthService;
+import com.runtracker.domain.member.entity.Member;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -53,5 +54,11 @@ public class MemberController {
     public ApiResponse<Void> withdrawMember(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         memberService.withdrawMember(userDetails.getMemberId());
         return ApiResponse.ok();
+    }
+
+    @GetMapping("/profile")
+    public ApiResponse<Member> getProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Member member = memberService.getMemberById(userDetails.getMemberId());
+        return ApiResponse.ok(member);
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.runtracker.domain.member.service.MemberService;
 import com.runtracker.domain.member.service.AuthService;
 import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.dto.MemberUpdateDTO;
+import com.runtracker.domain.member.dto.NotificationSettingDTO;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import com.runtracker.global.response.ApiResponse;
 import com.runtracker.global.security.UserDetailsImpl;
@@ -67,6 +68,13 @@ public class MemberController {
     public ApiResponse<Void> updateProfile(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                            @Valid @RequestBody MemberUpdateDTO.Request request) {
         memberService.updateProfile(userDetails.getMemberId(), request);
+        return ApiResponse.ok();
+    }
+
+    @PatchMapping("/notification")
+    public ApiResponse<Void> updateNotificationSetting(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                       @Valid @RequestBody NotificationSettingDTO.Request request) {
+        memberService.updateNotificationSetting(userDetails.getMemberId(), request);
         return ApiResponse.ok();
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/dto/MemberUpdateDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/dto/MemberUpdateDTO.java
@@ -1,0 +1,22 @@
+package com.runtracker.domain.member.dto;
+
+import lombok.*;
+
+public class MemberUpdateDTO {
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private String photo;
+        private String name;
+        private String introduce;
+        private String region;
+        private String difficulty;
+        private Integer age;
+        private Boolean gender;
+        private Boolean searchBlock;
+        private Boolean profileBlock;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/dto/NotificationSettingDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/dto/NotificationSettingDTO.java
@@ -1,0 +1,14 @@
+package com.runtracker.domain.member.dto;
+
+import lombok.*;
+
+public class NotificationSettingDTO {
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private Boolean notifyBlock;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/dto/RunningBackupDTO.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/dto/RunningBackupDTO.java
@@ -1,0 +1,58 @@
+package com.runtracker.domain.member.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class RunningBackupDTO {
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberBackupData {
+        private Long id;
+        private String name;
+        private String socialId;
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RecordBackupData {
+        private Long id;
+        private Long memberId;
+        private Long courseId;
+        private Long crewRunningId;
+        private Integer runningTime;
+        private LocalDateTime startedAt;
+        private LocalDateTime finishedAt;
+        private Double distance;
+        private Integer walk;
+        private Integer calorie;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BackupData {
+        private MemberBackupData member;
+        private List<RecordBackupData> runningRecords;
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BackupInfo {
+        private Long backupId;
+        private String backupType;
+        private Integer recordCount;
+        private String updatedAt;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/entity/Member.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/entity/Member.java
@@ -35,7 +35,7 @@ public class Member extends BaseEntity {
     @Column(name = "age")
     private Integer age;
 
-    @Column(name = "gender")
+    @Column(name = "gender", columnDefinition = "TINYINT(1)")
     private Boolean gender;
 
     @Column(name = "region", length = 100)
@@ -80,14 +80,17 @@ public class Member extends BaseEntity {
         this.notifyBlock = notifyBlock != null ? notifyBlock : true;
     }
 
-    public void updateProfile(String name, String introduce, Integer age, Boolean gender, 
-                            String region, String difficulty) {
-        this.name = name;
-        this.introduce = introduce;
-        this.age = age;
-        this.gender = gender;
-        this.region = region;
-        this.difficulty = difficulty;
+    public void updateProfile(String photo, String name, String introduce, Integer age, Boolean gender, 
+                            String region, String difficulty, Boolean searchBlock, Boolean profileBlock) {
+        if (photo != null) this.photo = photo;
+        if (name != null) this.name = name;
+        if (introduce != null) this.introduce = introduce;
+        if (age != null) this.age = age;
+        if (gender != null) this.gender = gender;
+        if (region != null) this.region = region;
+        if (difficulty != null) this.difficulty = difficulty;
+        if (searchBlock != null) this.searchBlock = searchBlock;
+        if (profileBlock != null) this.profileBlock = profileBlock;
     }
 
     public void updatePhoto(String photo) {

--- a/runtracker/src/main/java/com/runtracker/domain/member/entity/Member.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/entity/Member.java
@@ -100,4 +100,10 @@ public class Member extends BaseEntity {
     public void updateTemperature(Double temperature) {
         this.temperature = temperature;
     }
+    
+    public void updateNotificationSetting(Boolean notifyBlock) {
+        if (notifyBlock != null) {
+            this.notifyBlock = notifyBlock;
+        }
+    }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/member/entity/RunningBackup.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/entity/RunningBackup.java
@@ -1,0 +1,38 @@
+package com.runtracker.domain.member.entity;
+
+import com.runtracker.domain.member.enums.BackupType;
+import com.runtracker.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "running_backup")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RunningBackup extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "backup_data", columnDefinition = "JSON")
+    private String backupData;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "backup_type", nullable = false)
+    private BackupType backupType;
+    
+    public void updateBackupData(String backupData) {
+        this.backupData = backupData;
+        this.backupType = BackupType.ORIGINAL;
+    }
+    
+    public void markAsRestored() {
+        this.backupType = BackupType.RESTORED;
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/enums/BackupType.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/enums/BackupType.java
@@ -1,0 +1,13 @@
+package com.runtracker.domain.member.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BackupType {
+    ORIGINAL("저장된 백업"),
+    RESTORED("복원된 백업");
+
+    private final String description;
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/enums/MemberErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/enums/MemberErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode implements ResponseCode {
 
     MEMBER_NOT_FOUND("M001", "Member not found"),
-    MEMBER_WITHDRAWAL_FAILED("M002", "Member withdrawal failed");
+    MEMBER_WITHDRAWAL_FAILED("M002", "Member withdrawal failed"),
+    INVALID_DIFFICULTY("M003", "Invalid difficulty value");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/member/enums/MemberErrorCode.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/enums/MemberErrorCode.java
@@ -10,7 +10,11 @@ public enum MemberErrorCode implements ResponseCode {
 
     MEMBER_NOT_FOUND("M001", "Member not found"),
     MEMBER_WITHDRAWAL_FAILED("M002", "Member withdrawal failed"),
-    INVALID_DIFFICULTY("M003", "Invalid difficulty value");
+    INVALID_DIFFICULTY("M003", "Invalid difficulty value"),
+    BACKUP_NOT_FOUND("M004", "Backup not found"),
+    BACKUP_SERIALIZATION_FAILED("M005", "Failed to serialize backup data"),
+    BACKUP_DESERIALIZATION_FAILED("M006", "Failed to deserialize backup data"),
+    BACKUP_ALREADY_RESTORED("M007", "Backup has already been restored");
 
     private final String statusCode;
     private final String message;

--- a/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupAlreadyRestoredException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupAlreadyRestoredException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.member.exception;
+
+import com.runtracker.domain.member.enums.MemberErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class BackupAlreadyRestoredException extends CustomException {
+    public BackupAlreadyRestoredException(String message) {
+        super(MemberErrorCode.BACKUP_ALREADY_RESTORED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupDeserializationException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupDeserializationException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.member.exception;
+
+import com.runtracker.domain.member.enums.MemberErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class BackupDeserializationException extends CustomException {
+    public BackupDeserializationException(String message) {
+        super(MemberErrorCode.BACKUP_DESERIALIZATION_FAILED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupNotFoundException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupNotFoundException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.member.exception;
+
+import com.runtracker.domain.member.enums.MemberErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class BackupNotFoundException extends CustomException {
+    public BackupNotFoundException(String message) {
+        super(MemberErrorCode.BACKUP_NOT_FOUND, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupSerializationException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/exception/BackupSerializationException.java
@@ -1,0 +1,10 @@
+package com.runtracker.domain.member.exception;
+
+import com.runtracker.domain.member.enums.MemberErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class BackupSerializationException extends CustomException {
+    public BackupSerializationException(String message) {
+        super(MemberErrorCode.BACKUP_SERIALIZATION_FAILED, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/exception/InvalidDifficultyException.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/exception/InvalidDifficultyException.java
@@ -1,0 +1,15 @@
+package com.runtracker.domain.member.exception;
+
+import com.runtracker.domain.member.enums.MemberErrorCode;
+import com.runtracker.global.exception.CustomException;
+
+public class InvalidDifficultyException extends CustomException {
+
+    public InvalidDifficultyException() {
+        super(MemberErrorCode.INVALID_DIFFICULTY);
+    }
+
+    public InvalidDifficultyException(String message) {
+        super(MemberErrorCode.INVALID_DIFFICULTY, message);
+    }
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/repository/RunningBackupRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/repository/RunningBackupRepository.java
@@ -1,0 +1,12 @@
+package com.runtracker.domain.member.repository;
+
+import com.runtracker.domain.member.entity.RunningBackup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RunningBackupRepository extends JpaRepository<RunningBackup, Long> {
+    Optional<RunningBackup> findByMemberId(Long memberId);
+}

--- a/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
@@ -88,6 +88,11 @@ public class MemberService {
         }
     }
 
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("Member not found with id: " + memberId));
+    }
+
     @Transactional
     public void withdrawMember(Long memberId) {
         Member member = memberRepository.findById(memberId)

--- a/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
@@ -5,6 +5,9 @@ import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.repository.MemberRepository;
 import com.runtracker.domain.course.repository.CourseRepository;
 import com.runtracker.domain.member.exception.MemberNotFoundException;
+import com.runtracker.domain.member.exception.InvalidDifficultyException;
+import com.runtracker.domain.member.dto.MemberUpdateDTO;
+import com.runtracker.domain.course.enums.Difficulty;
 import com.runtracker.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -91,6 +94,36 @@ public class MemberService {
     public Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("Member not found with id: " + memberId));
+    }
+
+    @Transactional
+    public Member updateProfile(Long memberId, MemberUpdateDTO.Request request) {
+        Member member = getMemberById(memberId);
+
+        if (request.getDifficulty() != null) {
+            validateDifficulty(request.getDifficulty());
+        }
+        
+        member.updateProfile(
+                request.getPhoto(),
+                request.getName(),
+                request.getIntroduce(),
+                request.getAge(),
+                request.getGender(),
+                request.getRegion(),
+                request.getDifficulty(),
+                request.getSearchBlock(),
+                request.getProfileBlock()
+        );
+        return member;
+    }
+    
+    private void validateDifficulty(String difficulty) {
+        try {
+            Difficulty.valueOf(difficulty);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidDifficultyException("Invalid difficulty value. Must be one of: EASY, MEDIUM, HARD");
+        }
     }
 
     @Transactional

--- a/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.runtracker.domain.course.repository.CourseRepository;
 import com.runtracker.domain.member.exception.MemberNotFoundException;
 import com.runtracker.domain.member.exception.InvalidDifficultyException;
 import com.runtracker.domain.member.dto.MemberUpdateDTO;
+import com.runtracker.domain.member.dto.NotificationSettingDTO;
 import com.runtracker.domain.course.enums.Difficulty;
 import com.runtracker.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -124,6 +125,12 @@ public class MemberService {
         } catch (IllegalArgumentException e) {
             throw new InvalidDifficultyException("Invalid difficulty value. Must be one of: EASY, MEDIUM, HARD");
         }
+    }
+
+    @Transactional
+    public void updateNotificationSetting(Long memberId, NotificationSettingDTO.Request request) {
+        Member member = getMemberById(memberId);
+        member.updateNotificationSetting(request.getNotifyBlock());
     }
 
     @Transactional

--- a/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
+++ b/runtracker/src/main/java/com/runtracker/domain/member/service/MemberService.java
@@ -2,14 +2,27 @@ package com.runtracker.domain.member.service;
 
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.domain.member.entity.Member;
+import com.runtracker.domain.member.entity.RunningBackup;
 import com.runtracker.domain.member.repository.MemberRepository;
+import com.runtracker.domain.member.repository.RunningBackupRepository;
 import com.runtracker.domain.course.repository.CourseRepository;
+import com.runtracker.domain.record.repository.RecordRepository;
+import com.runtracker.domain.record.entity.RunningRecord;
 import com.runtracker.domain.member.exception.MemberNotFoundException;
 import com.runtracker.domain.member.exception.InvalidDifficultyException;
+import com.runtracker.domain.member.exception.BackupNotFoundException;
+import com.runtracker.domain.member.exception.BackupSerializationException;
+import com.runtracker.domain.member.exception.BackupDeserializationException;
+import com.runtracker.domain.member.exception.BackupAlreadyRestoredException;
 import com.runtracker.domain.member.dto.MemberUpdateDTO;
 import com.runtracker.domain.member.dto.NotificationSettingDTO;
+import com.runtracker.domain.member.dto.RunningBackupDTO;
+import com.runtracker.domain.member.enums.BackupType;
 import com.runtracker.domain.course.enums.Difficulty;
 import com.runtracker.global.jwt.JwtUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -27,6 +41,9 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final CourseRepository courseRepository;
+    private final RecordRepository recordRepository;
+    private final RunningBackupRepository backupRepository;
+    private final ObjectMapper objectMapper;
     private final JwtUtil jwtUtil;
 
     @Transactional
@@ -153,5 +170,137 @@ public class MemberService {
 
         courseRepository.deleteByMemberId(memberId);
         memberRepository.delete(member);
+    }
+
+    @Transactional
+    public void createBackup(Long memberId) {
+        try {
+            Member member = getMemberById(memberId);
+            List<RunningRecord> runningRecords = recordRepository.findByMemberId(memberId);
+            
+            RunningBackupDTO.MemberBackupData memberBackupData = RunningBackupDTO.MemberBackupData.builder()
+                    .id(member.getId())
+                    .name(member.getName())
+                    .socialId(member.getSocialId())
+                    .build();
+            
+            List<RunningBackupDTO.RecordBackupData> recordBackupDataList = runningRecords.stream()
+                    .map(record -> RunningBackupDTO.RecordBackupData.builder()
+                            .id(record.getId())
+                            .memberId(record.getMemberId())
+                            .courseId(record.getCourseId())
+                            .crewRunningId(record.getCrewRunningId())
+                            .runningTime(record.getRunningTime())
+                            .startedAt(record.getStartedAt())
+                            .finishedAt(record.getFinishedAt())
+                            .distance(record.getDistance())
+                            .walk(record.getWalk())
+                            .calorie(record.getCalorie())
+                            .createdAt(record.getCreatedAt())
+                            .updatedAt(record.getUpdatedAt())
+                            .build())
+                    .toList();
+            
+            RunningBackupDTO.BackupData backupData = RunningBackupDTO.BackupData.builder()
+                    .member(memberBackupData)
+                    .runningRecords(recordBackupDataList)
+                    .build();
+            
+            String backupDataJson = objectMapper.writeValueAsString(backupData);
+            
+            Optional<RunningBackup> existingBackup = backupRepository.findByMemberId(memberId);
+            
+            if (existingBackup.isPresent()) {
+                existingBackup.get().updateBackupData(backupDataJson);
+            } else {
+                RunningBackup newBackup = RunningBackup.builder()
+                        .memberId(memberId)
+                        .backupData(backupDataJson)
+                        .backupType(BackupType.ORIGINAL)
+                        .build();
+                backupRepository.save(newBackup);
+            }
+            
+        } catch (JsonProcessingException e) {
+            throw new BackupSerializationException("Failed to serialize backup data for member: " + memberId);
+        } catch (Exception e) {
+            throw new BackupSerializationException("Failed to create backup for member: " + memberId);
+        }
+    }
+
+    @Transactional
+    public void restoreRunningRecords(Long memberId) {
+        Optional<RunningBackup> backup = backupRepository.findByMemberId(memberId);
+        
+        if (backup.isEmpty()) {
+            throw new BackupNotFoundException("No backup found for member: " + memberId);
+        }
+        
+        RunningBackup backupEntity = backup.get();
+        
+        if (BackupType.RESTORED.equals(backupEntity.getBackupType())) {
+            throw new BackupAlreadyRestoredException("This backup has already been restored");
+        }
+        
+        try {
+            RunningBackupDTO.BackupData backupData = objectMapper.readValue(
+                    backup.get().getBackupData(), 
+                    new TypeReference<>() {}
+            );
+            
+            List<RunningRecord> currentRecords = recordRepository.findByMemberId(memberId);
+            
+            for (RunningBackupDTO.RecordBackupData backupRecord : backupData.getRunningRecords()) {
+                boolean recordExists = currentRecords.stream()
+                        .anyMatch(current -> current.getId().equals(backupRecord.getId()));
+                
+                if (!recordExists) {
+                    RunningRecord newRecord = RunningRecord.builder()
+                            .memberId(backupRecord.getMemberId())
+                            .courseId(backupRecord.getCourseId())
+                            .crewRunningId(backupRecord.getCrewRunningId())
+                            .runningTime(backupRecord.getRunningTime())
+                            .startedAt(backupRecord.getStartedAt())
+                            .finishedAt(backupRecord.getFinishedAt())
+                            .distance(backupRecord.getDistance())
+                            .walk(backupRecord.getWalk())
+                            .calorie(backupRecord.getCalorie())
+                            .build();
+                    recordRepository.save(newRecord);
+                }
+            }
+
+            backupEntity.markAsRestored();
+            
+        } catch (JsonProcessingException e) {
+            throw new BackupDeserializationException("Failed to deserialize backup data for member: " + memberId);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public RunningBackupDTO.BackupInfo getBackupInfo(Long memberId) {
+        Optional<RunningBackup> backup = backupRepository.findByMemberId(memberId);
+        
+        if (backup.isEmpty()) {
+            throw new BackupNotFoundException("No backup found for member: " + memberId);
+        }
+        
+        RunningBackup backupEntity = backup.get();
+        
+        try {
+            RunningBackupDTO.BackupData backupData = objectMapper.readValue(
+                    backupEntity.getBackupData(), 
+                    new TypeReference<>() {}
+            );
+            
+            return RunningBackupDTO.BackupInfo.builder()
+                    .backupId(backupEntity.getId())
+                    .backupType(backupEntity.getBackupType().name())
+                    .recordCount(backupData.getRunningRecords().size())
+                    .updatedAt(backupEntity.getUpdatedAt().toString())
+                    .build();
+        } catch (JsonProcessingException e) {
+            throw new BackupDeserializationException("Failed to parse backup data for member: " + memberId);
+        }
     }
 }

--- a/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
+++ b/runtracker/src/main/java/com/runtracker/domain/record/repository/RecordRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 @Repository
 public interface RecordRepository extends JpaRepository<RunningRecord, Long> {
     
+    List<RunningRecord> findByMemberId(Long memberId);
+    
     List<RunningRecord> findByMemberIdOrderByRunningTimeDesc(Long memberId);
     
     @Query("SELECT r FROM RunningRecord r WHERE r.memberId = :memberId AND DATE(r.runningTime) BETWEEN :startDate AND :endDate ORDER BY r.runningTime DESC")

--- a/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.runtracker.domain.member.controller;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.runtracker.RunTrackerDocumentApiTester;
+import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import org.junit.jupiter.api.Test;
@@ -175,6 +176,67 @@ class MemberControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
                                                 fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
                                                 fieldWithPath("body").type(JsonFieldType.NULL).description("응답 본문 (null)").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void getProfileTest() throws Exception {
+        // given
+        Member member = Member.builder()
+                .socialAttr("kakao")
+                .socialId("kakao_12345")
+                .photo("https://example.com/photo.jpg")
+                .name("홍길동")
+                .introduce("안녕하세요! 러닝을 좋아하는 홍길동입니다.")
+                .age(25)
+                .gender(true)
+                .region("서울")
+                .difficulty("초급")
+                .temperature(36.5)
+                .point(100)
+                .searchBlock(false)
+                .profileBlock(false)
+                .notifyBlock(true)
+                .build();
+
+        given(memberService.getMemberById(anyLong())).willReturn(member);
+
+        // when & then
+        this.mockMvc.perform(get("/api/members/profile")
+                        .header("Authorization", "Bearer access_token_example"))
+                .andExpect(status().isOk())
+                .andDo(document("member-get-profile",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("users")
+                                        .description("로그인한 사용자 프로필 조회")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body.id").type(JsonFieldType.NUMBER).description("회원 ID").optional(),
+                                                fieldWithPath("body.socialAttr").type(JsonFieldType.STRING).description("소셜 로그인 제공자").optional(),
+                                                fieldWithPath("body.socialId").type(JsonFieldType.STRING).description("소셜 로그인 ID"),
+                                                fieldWithPath("body.photo").type(JsonFieldType.STRING).description("프로필 사진 URL").optional(),
+                                                fieldWithPath("body.name").type(JsonFieldType.STRING).description("이름").optional(),
+                                                fieldWithPath("body.introduce").type(JsonFieldType.STRING).description("자기소개").optional(),
+                                                fieldWithPath("body.age").type(JsonFieldType.NUMBER).description("나이").optional(),
+                                                fieldWithPath("body.gender").type(JsonFieldType.BOOLEAN).description("성별 (true: 남성, false: 여성)").optional(),
+                                                fieldWithPath("body.region").type(JsonFieldType.STRING).description("지역").optional(),
+                                                fieldWithPath("body.difficulty").type(JsonFieldType.STRING).description("러닝 난이도").optional(),
+                                                fieldWithPath("body.temperature").type(JsonFieldType.NUMBER).description("사용자 온도"),
+                                                fieldWithPath("body.point").type(JsonFieldType.NUMBER).description("포인트"),
+                                                fieldWithPath("body.searchBlock").type(JsonFieldType.BOOLEAN).description("검색 차단 여부"),
+                                                fieldWithPath("body.profileBlock").type(JsonFieldType.BOOLEAN).description("프로필 차단 여부"),
+                                                fieldWithPath("body.notifyBlock").type(JsonFieldType.BOOLEAN).description("알림 차단 여부"),
+                                                fieldWithPath("body.createdAt").type(JsonFieldType.STRING).description("생성 일시").optional(),
+                                                fieldWithPath("body.updatedAt").type(JsonFieldType.STRING).description("수정 일시").optional()
                                         )
                                         .build()
                         )

--- a/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
@@ -4,6 +4,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.runtracker.RunTrackerDocumentApiTester;
 import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.dto.MemberUpdateDTO;
+import com.runtracker.domain.member.dto.NotificationSettingDTO;
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import org.junit.jupiter.api.Test;
@@ -313,6 +314,39 @@ class MemberControllerTest extends RunTrackerDocumentApiTester {
     }
 
     @Test
+    void updateNotificationSettingTest() throws Exception {
+        // given
+        doNothing().when(memberService).updateNotificationSetting(anyLong(), any(NotificationSettingDTO.Request.class));
+
+        // when & then
+        this.mockMvc.perform(patch("/api/members/notification")
+                        .header("Authorization", "Bearer access_token_example")
+                        .contentType("application/json")
+                        .content(toJson(Map.of("notifyBlock", false))))
+                .andExpect(status().isOk())
+                .andDo(document("member-update-notification",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("users")
+                                        .summary("알림 설정 수정")
+                                        .description("notifyBlock - 알림 차단 여부 (true: 알림 차단, false: 알림 허용")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .requestFields(
+                                                fieldWithPath("notifyBlock").type(JsonFieldType.BOOLEAN).description("알림 차단 여부 (true: 알림 차단/OFF, false: 알림 허용/ON)")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
     void withdrawMemberTest() throws Exception {
         // given
         doNothing().when(memberService).withdrawMember(anyLong());
@@ -325,7 +359,8 @@ class MemberControllerTest extends RunTrackerDocumentApiTester {
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag("users")
-                                        .description("회원 탈퇴")
+                                        .summary("회원 탈퇴")
+                                        .description("로그인한 사용자의 계정을 탈퇴합니다")
                                         .requestHeaders(
                                                 headerWithName("Authorization").description("Bearer 토큰")
                                         )

--- a/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
@@ -3,6 +3,7 @@ package com.runtracker.domain.member.controller;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.runtracker.RunTrackerDocumentApiTester;
 import com.runtracker.domain.member.entity.Member;
+import com.runtracker.domain.member.dto.MemberUpdateDTO;
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithNam
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -194,7 +196,7 @@ class MemberControllerTest extends RunTrackerDocumentApiTester {
                 .age(25)
                 .gender(true)
                 .region("서울")
-                .difficulty("초급")
+                .difficulty("EASY")
                 .temperature(36.5)
                 .point(100)
                 .searchBlock(false)
@@ -237,6 +239,73 @@ class MemberControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("body.notifyBlock").type(JsonFieldType.BOOLEAN).description("알림 차단 여부"),
                                                 fieldWithPath("body.createdAt").type(JsonFieldType.STRING).description("생성 일시").optional(),
                                                 fieldWithPath("body.updatedAt").type(JsonFieldType.STRING).description("수정 일시").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void updateProfileTest() throws Exception {
+        // given
+        Member updatedMember = Member.builder()
+                .socialAttr("kakao")
+                .socialId("kakao_12345")
+                .photo("https://example.com/new-photo.jpg")
+                .name("김철수")
+                .introduce("업데이트된 자기소개입니다.")
+                .age(30)
+                .gender(true)
+                .region("부산")
+                .difficulty("MEDIUM")
+                .temperature(36.5)
+                .point(100)
+                .searchBlock(true)
+                .profileBlock(false)
+                .notifyBlock(true)
+                .build();
+
+        given(memberService.updateProfile(anyLong(), any(MemberUpdateDTO.Request.class))).willReturn(updatedMember);
+
+        // when & then
+        this.mockMvc.perform(patch("/api/members/update")
+                        .header("Authorization", "Bearer access_token_example")
+                        .contentType("application/json")
+                        .content(toJson(Map.of(
+                                "photo", "https://example.com/new-photo.jpg",
+                                "name", "김철수",
+                                "introduce", "업데이트된 자기소개입니다.",
+                                "age", 30,
+                                "gender", true,
+                                "region", "부산",
+                                "difficulty", "MEDIUM",
+                                "searchBlock", true,
+                                "profileBlock", false
+                        ))))
+                .andExpect(status().isOk())
+                .andDo(document("member-update-profile",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("users")
+                                        .description("로그인한 사용자 프로필 수정")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("엑세스 토큰")
+                                        )
+                                        .requestFields(
+                                                fieldWithPath("photo").type(JsonFieldType.STRING).description("프로필 사진 URL").optional(),
+                                                fieldWithPath("name").type(JsonFieldType.STRING).description("닉네임").optional(),
+                                                fieldWithPath("introduce").type(JsonFieldType.STRING).description("자기소개").optional(),
+                                                fieldWithPath("age").type(JsonFieldType.NUMBER).description("나이").optional(),
+                                                fieldWithPath("gender").type(JsonFieldType.BOOLEAN).description("성별 (true: 남성, false: 여성)").optional(),
+                                                fieldWithPath("region").type(JsonFieldType.STRING).description("지역").optional(),
+                                                fieldWithPath("difficulty").type(JsonFieldType.STRING).description("러닝 난이도 (EASY, MEDIUM, HARD)").optional(),
+                                                fieldWithPath("searchBlock").type(JsonFieldType.BOOLEAN).description("크루 검색 공개 여부").optional(),
+                                                fieldWithPath("profileBlock").type(JsonFieldType.BOOLEAN).description("프로필 공개 여부").optional()
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional()
                                         )
                                         .build()
                         )

--- a/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
+++ b/runtracker/src/test/java/com/runtracker/domain/member/controller/MemberControllerTest.java
@@ -5,6 +5,7 @@ import com.runtracker.RunTrackerDocumentApiTester;
 import com.runtracker.domain.member.entity.Member;
 import com.runtracker.domain.member.dto.MemberUpdateDTO;
 import com.runtracker.domain.member.dto.NotificationSettingDTO;
+import com.runtracker.domain.member.dto.RunningBackupDTO;
 import com.runtracker.domain.member.service.dto.LoginTokenDto;
 import com.runtracker.global.jwt.dto.TokenDataDto;
 import org.junit.jupiter.api.Test;
@@ -369,6 +370,104 @@ class MemberControllerTest extends RunTrackerDocumentApiTester {
                                                 fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
                                                 fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
                                                 fieldWithPath("body").type(JsonFieldType.NULL).description("응답 본문 (null)").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void createBackupTest() throws Exception {
+        // given
+        doNothing().when(memberService).createBackup(anyLong());
+
+        // when & then
+        this.mockMvc.perform(post("/api/members/backup")
+                        .header("Authorization", "Bearer access_token_example"))
+                .andExpect(status().isOk())
+                .andDo(document("member-backup-create",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("backup")
+                                        .summary("데이터 백업 생성")
+                                        .description("사용자의 러닝 기록을 백업합니다. backup_type이 ORIGINAL이면 복원 가능한 상태, RESTORED이면 이미 복원된 상태라 다시 백업해야함.")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("Bearer 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.NULL).description("응답 본문 (null)").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void restoreBackupTest() throws Exception {
+        // given
+        doNothing().when(memberService).restoreRunningRecords(anyLong());
+
+        // when & then
+        this.mockMvc.perform(post("/api/members/restore")
+                        .header("Authorization", "Bearer access_token_example"))
+                .andExpect(status().isOk())
+                .andDo(document("member-backup-restore",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("backup")
+                                        .summary("데이터 백업 복원")
+                                        .description("백업된 러닝 기록 중 현재 없는 기록만 복원합니다. 기존 기록은 변경되지 않습니다.")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("Bearer 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.NULL).description("응답 본문 (null)").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    void getBackupInfoTest() throws Exception {
+        // given
+        RunningBackupDTO.BackupInfo backupInfo = RunningBackupDTO.BackupInfo.builder()
+                .backupId(1L)
+                .backupType("ORIGINAL")
+                .recordCount(15)
+                .updatedAt("2024-01-15T14:30:00")
+                .build();
+
+        given(memberService.getBackupInfo(anyLong())).willReturn(backupInfo);
+
+        // when & then
+        this.mockMvc.perform(get("/api/members/backup/info")
+                        .header("Authorization", "Bearer access_token_example"))
+                .andExpect(status().isOk())
+                .andDo(document("member-backup-info",
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("backup")
+                                        .summary("백업 정보 조회")
+                                        .description("사용자의 백업 정보를 조회합니다. 백업이 없으면 null을 반환합니다.")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("Bearer 토큰")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("status.statusCode").type(JsonFieldType.STRING).description("상태 코드"),
+                                                fieldWithPath("status.message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                                fieldWithPath("status.description").type(JsonFieldType.STRING).description("상태 설명").optional(),
+                                                fieldWithPath("body").type(JsonFieldType.OBJECT).description("백업 정보").optional(),
+                                                fieldWithPath("body.backupId").type(JsonFieldType.NUMBER).description("백업 ID").optional(),
+                                                fieldWithPath("body.backupType").type(JsonFieldType.STRING).description("백업 타입").optional(),
+                                                fieldWithPath("body.recordCount").type(JsonFieldType.NUMBER).description("백업된 기록 수").optional(),
+                                                fieldWithPath("body.updatedAt").type(JsonFieldType.STRING).description("백업 업데이트 시간").optional()
                                         )
                                         .build()
                         )


### PR DESCRIPTION
# Summary
- 프로필 관리 API: 로그인된 사용자의 프로필 조회, 부분 수정(PATCH), 알림 설정 관리 API 구현
- 데이터 백업 및 복구 시스템: 사용자의 런닝 기록을 JSON 형태로 백업하고 데이터 손실 시 복구할 수 있는 시스템 구현
- 상태 관리: 백업 상태(ORIGINAL/RESTORED) 관리로 무한 데이터 증식 방지
- 에러 처리: 도메인별 커스텀 예외와 에러 코드 추가

## 주요 기능

### 프로필 관리
- 프로필 조회: JWT 토큰 기반 본인 프로필 조회
- 부분 프로필 수정: 사진, 닉네임, 소개, 지역, 난이도, 공개설정, 나이, 성별 수정
- 알림 설정: 알림 설정 별도 관리 
- Enum 유효성 검증: Difficulty 필드 유효성 검증 및 커스텀 예외 처리

### 백업 시스템
- 백업 생성: 사용자 정보 + 런닝 기록을 JSON으로 직렬화하여 저장
- 복구: 기존 기록과 ID 비교하여 누락된 기록만 복원 (중복 방지)
- 상태 추적: ORIGINAL(백업됨) ↔ RESTORED(복원됨) 상태 관리
- 백업 정보: 백업 ID, 타입, 기록 개수, 업데이트 시간 조회

## API 엔드포인트
- GET    /api/members/profile              # 프로필 조회
- PATCH  /api/members/profile              # 프로필 수정
- PATCH  /api/members/notifications        # 알림 설정 수정
- POST   /api/members/backup               # 백업 생성/업데이트
- POST   /api/members/backup/restore       # 백업 복구
- GET    /api/members/backup/info          # 백업 정보 조회